### PR TITLE
feat: Add TypeScript types and Preact foundation (#6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 target/
 dist/
 build/
+.vite/
 
 # OS files
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -897,6 +897,32 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@preact/signals": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
+      "integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": "10.x"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.0.tgz",
+      "integrity": "sha512-AowtCcCU/33lFlh1zRFf/u+12rfrhtNakj7UpaGEsmMwUKpKWMVvcktOGcwBBNiB4lWrZWc01LhiyyzVklJyaQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@prefresh/babel-plugin": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@prefresh/babel-plugin/-/babel-plugin-0.5.3.tgz",
@@ -2593,6 +2619,7 @@
       "name": "tossue-extension",
       "version": "0.1.0",
       "dependencies": {
+        "@preact/signals": "^1.3.1",
         "preact": "^10.25.4"
       },
       "devDependencies": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@preact/signals": "^1.3.1",
     "preact": "^10.25.4"
   },
   "devDependencies": {

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -1,11 +1,23 @@
+import type {
+  TabState,
+  UserAction,
+  ConsoleEntry,
+  NetworkEntry,
+  IssueDraft,
+  Message,
+  MessageResponse,
+  DevtoolsEventPayload,
+} from "../shared/types";
+
 const MAX_ACTIONS = 25;
 const MAX_CONSOLE = 20;
 const MAX_REQUESTS = 20;
 const STORAGE_KEYS = {
-  defaultRepo: "defaultRepo"
+  defaultRepo: "defaultRepo",
 };
-const tabState = new Map();
-const screencastSessions = new Map();
+
+const tabState = new Map<number, TabState>();
+const screencastSessions = new Map<number, { attachedAt: number }>();
 let nextActionId = 1;
 
 chrome.runtime.onInstalled.addListener(() => {
@@ -15,14 +27,17 @@ chrome.runtime.onInstalled.addListener(() => {
 chrome.debugger.onEvent.addListener(handleDebuggerEvent);
 chrome.debugger.onDetach.addListener(handleDebuggerDetach);
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message: Message, sender, sendResponse) => {
   handleMessage(message, sender)
     .then((result) => sendResponse({ ok: true, ...result }))
     .catch((error) => sendResponse({ ok: false, error: error.message }));
   return true;
 });
 
-async function handleMessage(message, sender) {
+async function handleMessage(
+  message: Message,
+  sender: chrome.runtime.MessageSender
+): Promise<Partial<MessageResponse>> {
   const tabId = message.tabId ?? sender.tab?.id;
 
   switch (message.type) {
@@ -37,32 +52,36 @@ async function handleMessage(message, sender) {
     case "HIGHLIGHT_SELECTED_AREA":
       await sendTabMessage(tabId, {
         type: "HIGHLIGHT_SELECTED_AREA",
-        payload: message.payload
+        payload: message.payload,
       });
       return { highlighted: true };
     case "CLEAR_SELECTED_AREA_HIGHLIGHT":
       await sendTabMessage(tabId, { type: "CLEAR_SELECTED_AREA_HIGHLIGHT" });
       return { cleared: true };
     case "AREA_SELECTED":
-      updateState(tabId, { selectedArea: message.payload });
+      updateState(tabId, { selectedArea: message.payload as TabState["selectedArea"] });
       return await respondWithState(tabId);
     case "CAPTURE_RECT_SELECTED":
-      updateState(tabId, { captureRect: message.payload });
+      updateState(tabId, { captureRect: message.payload as TabState["captureRect"] });
       return await respondWithState(tabId);
     case "CLEAR_SCREENSHOT":
       updateState(tabId, { captureRect: null, screenshotDataUrl: "" });
       return await respondWithState(tabId);
     case "ACTION_LOGGED":
-      appendAction(tabId, message.payload);
+      appendAction(tabId, message.payload as Partial<UserAction>);
       return await respondWithState(tabId);
     case "CLEAR_ACTIONS":
       mutateActions(tabId, () => []);
       return await respondWithState(tabId);
     case "DELETE_ACTION":
-      mutateActions(tabId, (actions) => actions.filter((action) => action.id !== message.payload?.id));
+      mutateActions(tabId, (actions) =>
+        actions.filter((action) => action.id !== (message.payload as { id: string })?.id)
+      );
       return await respondWithState(tabId);
     case "TRIM_ACTIONS_BEFORE":
-      mutateActions(tabId, (actions) => trimActionsBefore(actions, message.payload?.id));
+      mutateActions(tabId, (actions) =>
+        trimActionsBefore(actions, (message.payload as { id: string })?.id)
+      );
       return await respondWithState(tabId);
     case "UNDO_ACTION_EDIT":
       undoActionEdit(tabId);
@@ -71,14 +90,14 @@ async function handleMessage(message, sender) {
       redoActionEdit(tabId);
       return await respondWithState(tabId);
     case "CONSOLE_EVENT":
-      pushItem(tabId, "consoleEntries", message.payload, MAX_CONSOLE);
+      pushItem(tabId, "consoleEntries", message.payload as ConsoleEntry, MAX_CONSOLE);
       return await respondWithState(tabId);
     case "NETWORK_EVENT":
-      pushItem(tabId, "networkEntries", message.payload, MAX_REQUESTS);
+      pushItem(tabId, "networkEntries", message.payload as NetworkEntry, MAX_REQUESTS);
       return await respondWithState(tabId);
     case "STORE_FORM":
-      await persistDefaultRepo(message.payload?.repo);
-      updateState(tabId, { draft: message.payload });
+      await persistDefaultRepo((message.payload as IssueDraft)?.repo);
+      updateState(tabId, { draft: message.payload as IssueDraft });
       return await respondWithState(tabId);
     case "CAPTURE_SCREENSHOT":
       return { screenshotDataUrl: await captureScreenshot(tabId, sender.tab) };
@@ -87,24 +106,24 @@ async function handleMessage(message, sender) {
     case "STOP_TAB_RECORDING":
       return await stopTabRecording(tabId);
     case "DEVTOOLS_EVENT":
-      ingestDevtoolsEvent(tabId, message.payload);
+      ingestDevtoolsEvent(tabId, message.payload as DevtoolsEventPayload);
       return await respondWithState(tabId);
     default:
       throw new Error(`Unsupported message type: ${message.type}`);
   }
 }
 
-async function getState(tabId) {
+async function getState(tabId: number | undefined): Promise<TabState> {
   const baseState = getOrCreateState(tabId);
   const defaultRepo = await readDefaultRepo();
 
   if (defaultRepo && !baseState.draft.repo) {
-    const nextState = {
+    const nextState: TabState = {
       ...baseState,
       draft: {
         ...baseState.draft,
-        repo: defaultRepo
-      }
+        repo: defaultRepo,
+      },
     };
     if (tabId) {
       tabState.set(tabId, nextState);
@@ -115,7 +134,7 @@ async function getState(tabId) {
   return baseState;
 }
 
-function getOrCreateState(tabId) {
+function getOrCreateState(tabId: number | undefined): TabState {
   if (!tabId) {
     return createEmptyState();
   }
@@ -124,10 +143,10 @@ function getOrCreateState(tabId) {
     tabState.set(tabId, createEmptyState());
   }
 
-  return tabState.get(tabId);
+  return tabState.get(tabId)!;
 }
 
-function createEmptyState() {
+function createEmptyState(): TabState {
   return {
     selectedArea: null,
     captureRect: null,
@@ -142,37 +161,55 @@ function createEmptyState() {
       summary: "",
       currentBehavior: "",
       expectedBehavior: "",
-      labels: []
-    }
+      labels: [],
+    },
   };
 }
 
-function updateState(tabId, patch) {
+function updateState(tabId: number | undefined, patch: Partial<TabState>): void {
+  if (!tabId) return;
   const current = getOrCreateState(tabId);
   tabState.set(tabId, { ...current, ...patch });
 }
 
-function pushItem(tabId, key, item, limit) {
+function pushItem<K extends "consoleEntries" | "networkEntries">(
+  tabId: number | undefined,
+  key: K,
+  item: TabState[K][number],
+  limit: number
+): void {
+  if (!tabId) return;
   const current = getOrCreateState(tabId);
-  const items = [...current[key], item].slice(-limit);
+  const items = [...current[key], item].slice(-limit) as TabState[K];
   tabState.set(tabId, { ...current, [key]: items });
 }
 
-function appendAction(tabId, item) {
+function appendAction(tabId: number | undefined, item: Partial<UserAction>): void {
+  if (!tabId) return;
   const current = getOrCreateState(tabId);
-  const action = {
+  const action: UserAction = {
     id: item?.id || `action-${nextActionId++}`,
-    kind: item?.type === "navigation" ? "navigation" : item?.kind || "event",
-    ...item
+    kind: item?.type === "navigation" ? "navigation" : (item?.kind as UserAction["kind"]) || "event",
+    type: item?.type || "",
+    at: item?.at || new Date().toISOString(),
+    target: item?.target || "",
+    valueSnippet: item?.valueSnippet || "",
+    targetInfo: item?.targetInfo || null,
+    href: item?.href,
+    navigationKind: item?.navigationKind,
   };
   const actions = [...current.actions, action].slice(-MAX_ACTIONS);
   tabState.set(tabId, {
     ...current,
-    actions
+    actions,
   });
 }
 
-function mutateActions(tabId, transform) {
+function mutateActions(
+  tabId: number | undefined,
+  transform: (actions: UserAction[]) => UserAction[]
+): void {
+  if (!tabId) return;
   const current = getOrCreateState(tabId);
   const previousActions = current.actions.map(cloneAction);
   const nextActions = transform(previousActions.map(cloneAction)).slice(-MAX_ACTIONS);
@@ -181,11 +218,12 @@ function mutateActions(tabId, transform) {
     ...current,
     actions: nextActions,
     actionHistoryPast: [...current.actionHistoryPast, previousActions].slice(-20),
-    actionHistoryFuture: []
+    actionHistoryFuture: [],
   });
 }
 
-function undoActionEdit(tabId) {
+function undoActionEdit(tabId: number | undefined): void {
+  if (!tabId) return;
   const current = getOrCreateState(tabId);
   const previous = current.actionHistoryPast.at(-1);
   if (!previous) {
@@ -196,11 +234,15 @@ function undoActionEdit(tabId) {
     ...current,
     actions: previous.map(cloneAction),
     actionHistoryPast: current.actionHistoryPast.slice(0, -1),
-    actionHistoryFuture: [current.actions.map(cloneAction), ...current.actionHistoryFuture].slice(0, 20)
+    actionHistoryFuture: [current.actions.map(cloneAction), ...current.actionHistoryFuture].slice(
+      0,
+      20
+    ),
   });
 }
 
-function redoActionEdit(tabId) {
+function redoActionEdit(tabId: number | undefined): void {
+  if (!tabId) return;
   const current = getOrCreateState(tabId);
   const next = current.actionHistoryFuture[0];
   if (!next) {
@@ -211,15 +253,16 @@ function redoActionEdit(tabId) {
     ...current,
     actions: next.map(cloneAction),
     actionHistoryPast: [...current.actionHistoryPast, current.actions.map(cloneAction)].slice(-20),
-    actionHistoryFuture: current.actionHistoryFuture.slice(1)
+    actionHistoryFuture: current.actionHistoryFuture.slice(1),
   });
 }
 
-function cloneAction(action) {
+function cloneAction(action: UserAction): UserAction {
   return structuredClone(action);
 }
 
-function trimActionsBefore(actions, id) {
+function trimActionsBefore(actions: UserAction[], id: string | undefined): UserAction[] {
+  if (!id) return actions;
   const index = actions.findIndex((action) => action.id === id);
   if (index < 0) {
     return actions;
@@ -232,21 +275,27 @@ function trimActionsBefore(actions, id) {
   return actions.filter((_action, actionIndex) => actionIndex >= index);
 }
 
-function ingestDevtoolsEvent(tabId, payload) {
+function ingestDevtoolsEvent(
+  tabId: number | undefined,
+  payload: DevtoolsEventPayload | undefined
+): void {
   if (!tabId || !payload) {
     return;
   }
 
   if (payload.kind === "console") {
-    pushItem(tabId, "consoleEntries", payload.entry, MAX_CONSOLE);
+    pushItem(tabId, "consoleEntries", payload.entry as ConsoleEntry, MAX_CONSOLE);
   }
 
   if (payload.kind === "network") {
-    pushItem(tabId, "networkEntries", payload.entry, MAX_REQUESTS);
+    pushItem(tabId, "networkEntries", payload.entry as NetworkEntry, MAX_REQUESTS);
   }
 }
 
-async function captureScreenshot(tabId, senderTab) {
+async function captureScreenshot(
+  tabId: number | undefined,
+  senderTab: chrome.tabs.Tab | undefined
+): Promise<string> {
   let targetTab = senderTab;
 
   if (!targetTab && tabId) {
@@ -265,7 +314,7 @@ async function captureScreenshot(tabId, senderTab) {
   assertCapturableTab(targetTab);
 
   const screenshotDataUrl = await chrome.tabs.captureVisibleTab(targetTab.windowId, {
-    format: "png"
+    format: "png",
   });
 
   if (tabId) {
@@ -274,7 +323,10 @@ async function captureScreenshot(tabId, senderTab) {
   return screenshotDataUrl;
 }
 
-async function sendTabMessage(tabId, message) {
+async function sendTabMessage(
+  tabId: number | undefined,
+  message: Partial<Message>
+): Promise<unknown> {
   if (!tabId) {
     throw new Error("Unable to resolve the active tab.");
   }
@@ -288,15 +340,15 @@ async function sendTabMessage(tabId, message) {
 
     await chrome.scripting.executeScript({
       target: { tabId },
-      files: ["content.js"]
+      files: ["content.js"],
     });
 
     return await chrome.tabs.sendMessage(tabId, message);
   }
 }
 
-function shouldRetryContentScript(error) {
-  const message = String(error?.message || "");
+function shouldRetryContentScript(error: unknown): boolean {
+  const message = String((error as Error)?.message || "");
   return (
     message.includes("Receiving end does not exist") ||
     message.includes("Could not establish connection") ||
@@ -304,7 +356,9 @@ function shouldRetryContentScript(error) {
   );
 }
 
-async function startTabRecording(tabId) {
+async function startTabRecording(
+  tabId: number | undefined
+): Promise<{ started: boolean; alreadyRunning?: boolean }> {
   if (!tabId) {
     throw new Error("Unable to resolve the active tab for recording.");
   }
@@ -321,7 +375,7 @@ async function startTabRecording(tabId) {
   try {
     await chrome.debugger.attach(target, "1.3");
   } catch (error) {
-    if (!String(error?.message || "").includes("Another debugger is already attached")) {
+    if (!String((error as Error)?.message || "").includes("Another debugger is already attached")) {
       throw error;
     }
   }
@@ -331,7 +385,7 @@ async function startTabRecording(tabId) {
     await chrome.debugger.sendCommand(target, "Page.startScreencast", {
       format: "jpeg",
       quality: 80,
-      everyNthFrame: 1
+      everyNthFrame: 1,
     });
   } catch (error) {
     try {
@@ -341,13 +395,15 @@ async function startTabRecording(tabId) {
   }
 
   screencastSessions.set(tabId, {
-    attachedAt: Date.now()
+    attachedAt: Date.now(),
   });
 
   return { started: true };
 }
 
-async function stopTabRecording(tabId) {
+async function stopTabRecording(
+  tabId: number | undefined
+): Promise<{ stopped: boolean }> {
   if (!tabId) {
     return { stopped: true };
   }
@@ -367,26 +423,38 @@ async function stopTabRecording(tabId) {
     await chrome.debugger.detach(target);
   } catch (_error) {}
 
-  chrome.runtime.sendMessage({
-    type: "TAB_RECORDING_STOPPED",
-    tabId
-  }).catch(() => {});
+  chrome.runtime
+    .sendMessage({
+      type: "TAB_RECORDING_STOPPED",
+      tabId,
+    })
+    .catch(() => {});
 
   return { stopped: true };
 }
 
-function assertCapturableTab(tab) {
+function assertCapturableTab(tab: chrome.tabs.Tab): void {
   const url = String(tab?.url || "");
   if (!url) {
     return;
   }
 
-  if (url.startsWith("chrome://") || url.startsWith("chrome-extension://") || url.startsWith("edge://")) {
-    throw new Error("Chrome internal pages cannot be captured. Open a normal website tab and try again.");
+  if (
+    url.startsWith("chrome://") ||
+    url.startsWith("chrome-extension://") ||
+    url.startsWith("edge://")
+  ) {
+    throw new Error(
+      "Chrome internal pages cannot be captured. Open a normal website tab and try again."
+    );
   }
 }
 
-async function handleDebuggerEvent(source, method, params) {
+async function handleDebuggerEvent(
+  source: chrome.debugger.Debuggee,
+  method: string,
+  params?: { data?: string; metadata?: object; sessionId?: number }
+): Promise<void> {
   if (method !== "Page.screencastFrame" || !source.tabId) {
     return;
   }
@@ -396,21 +464,23 @@ async function handleDebuggerEvent(source, method, params) {
     return;
   }
 
-  chrome.runtime.sendMessage({
-    type: "TAB_RECORDING_FRAME",
-    tabId: source.tabId,
-    data: params.data,
-    metadata: params.metadata || {}
-  }).catch(() => {});
+  chrome.runtime
+    .sendMessage({
+      type: "TAB_RECORDING_FRAME",
+      tabId: source.tabId,
+      data: params?.data,
+      metadata: params?.metadata || {},
+    })
+    .catch(() => {});
 
   try {
     await chrome.debugger.sendCommand({ tabId: source.tabId }, "Page.screencastFrameAck", {
-      sessionId: params.sessionId
+      sessionId: params?.sessionId,
     });
   } catch (_error) {}
 }
 
-function handleDebuggerDetach(source) {
+function handleDebuggerDetach(source: chrome.debugger.Debuggee): void {
   if (!source.tabId) {
     return;
   }
@@ -420,33 +490,39 @@ function handleDebuggerDetach(source) {
   }
 
   screencastSessions.delete(source.tabId);
-  chrome.runtime.sendMessage({
-    type: "TAB_RECORDING_STOPPED",
-    tabId: source.tabId
-  }).catch(() => {});
+  chrome.runtime
+    .sendMessage({
+      type: "TAB_RECORDING_STOPPED",
+      tabId: source.tabId,
+    })
+    .catch(() => {});
 }
 
-async function respondWithState(tabId) {
+async function respondWithState(
+  tabId: number | undefined
+): Promise<{ state: TabState }> {
   const state = await getState(tabId);
   broadcastState(tabId, state);
   return { state };
 }
 
-function broadcastState(tabId, state) {
-  chrome.runtime.sendMessage({
-    type: "STATE_UPDATED",
-    tabId,
-    state
-  }).catch(() => {});
+function broadcastState(tabId: number | undefined, state: TabState): void {
+  chrome.runtime
+    .sendMessage({
+      type: "STATE_UPDATED",
+      tabId,
+      state,
+    })
+    .catch(() => {});
 }
 
-async function readDefaultRepo() {
+async function readDefaultRepo(): Promise<string> {
   const stored = await chrome.storage.local.get(STORAGE_KEYS.defaultRepo);
   return String(stored[STORAGE_KEYS.defaultRepo] || "").trim();
 }
 
-async function persistDefaultRepo(repo) {
+async function persistDefaultRepo(repo: string | undefined): Promise<void> {
   await chrome.storage.local.set({
-    [STORAGE_KEYS.defaultRepo]: String(repo || "").trim()
+    [STORAGE_KEYS.defaultRepo]: String(repo || "").trim(),
   });
 }

--- a/packages/extension/src/shared/types/content.ts
+++ b/packages/extension/src/shared/types/content.ts
@@ -1,0 +1,36 @@
+import type { SelectedArea, Rect, Viewport, FrameworkInfo } from "./state";
+
+export type OverlayState = {
+  active: boolean;
+  mode: "area" | "capture" | "";
+  hoveredElement: Element | null;
+  outline: HTMLDivElement | null;
+  captureBox: HTMLDivElement | null;
+  previewOutline: HTMLDivElement | null;
+  toast: HTMLDivElement | null;
+  dragStart: { x: number; y: number } | null;
+};
+
+export type ActionEntry = {
+  type: string;
+  at: string;
+  target: string;
+  valueSnippet: string;
+  targetInfo: SelectedArea | null;
+  href?: string;
+  navigationKind?: string;
+};
+
+export type ContentMessage = {
+  type:
+    | "START_AREA_PICKER"
+    | "START_CAPTURE_PICKER"
+    | "HIGHLIGHT_SELECTED_AREA"
+    | "CLEAR_SELECTED_AREA_HIGHLIGHT"
+    | "AREA_SELECTED"
+    | "CAPTURE_RECT_SELECTED"
+    | "ACTION_LOGGED"
+    | "CONSOLE_EVENT"
+    | "NETWORK_EVENT";
+  payload?: unknown;
+};

--- a/packages/extension/src/shared/types/index.ts
+++ b/packages/extension/src/shared/types/index.ts
@@ -1,0 +1,2 @@
+export * from "./state";
+export * from "./messages";

--- a/packages/extension/src/shared/types/index.ts
+++ b/packages/extension/src/shared/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./state";
 export * from "./messages";
+export * from "./content";

--- a/packages/extension/src/shared/types/messages.ts
+++ b/packages/extension/src/shared/types/messages.ts
@@ -1,0 +1,64 @@
+import type {
+  TabState,
+  SelectedArea,
+  CaptureRect,
+  UserAction,
+  ConsoleEntry,
+  NetworkEntry,
+  IssueDraft,
+} from "./state";
+
+export type MessageType =
+  | "GET_ACTIVE_TAB_STATE"
+  | "START_AREA_PICKER"
+  | "START_CAPTURE_PICKER"
+  | "HIGHLIGHT_SELECTED_AREA"
+  | "CLEAR_SELECTED_AREA_HIGHLIGHT"
+  | "AREA_SELECTED"
+  | "CAPTURE_RECT_SELECTED"
+  | "CLEAR_SCREENSHOT"
+  | "ACTION_LOGGED"
+  | "CLEAR_ACTIONS"
+  | "DELETE_ACTION"
+  | "TRIM_ACTIONS_BEFORE"
+  | "UNDO_ACTION_EDIT"
+  | "REDO_ACTION_EDIT"
+  | "CONSOLE_EVENT"
+  | "NETWORK_EVENT"
+  | "STORE_FORM"
+  | "CAPTURE_SCREENSHOT"
+  | "START_TAB_RECORDING"
+  | "STOP_TAB_RECORDING"
+  | "DEVTOOLS_EVENT"
+  | "STATE_UPDATED"
+  | "TAB_RECORDING_FRAME"
+  | "TAB_RECORDING_STOPPED";
+
+export type Message = {
+  type: MessageType;
+  tabId?: number;
+  payload?: unknown;
+  state?: TabState;
+  data?: string;
+  metadata?: {
+    deviceWidth?: number;
+    deviceHeight?: number;
+  };
+};
+
+export type DevtoolsEventPayload = {
+  kind: "console" | "network";
+  entry: ConsoleEntry | NetworkEntry;
+};
+
+export type MessageResponse = {
+  ok: boolean;
+  error?: string;
+  state?: TabState;
+  started?: boolean;
+  stopped?: boolean;
+  alreadyRunning?: boolean;
+  highlighted?: boolean;
+  cleared?: boolean;
+  screenshotDataUrl?: string;
+};

--- a/packages/extension/src/shared/types/state.ts
+++ b/packages/extension/src/shared/types/state.ts
@@ -1,0 +1,126 @@
+export type Rect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type Viewport = {
+  width: number;
+  height: number;
+  devicePixelRatio: number;
+};
+
+export type FrameworkInfo = {
+  framework: "React" | "Vue" | "DOM";
+  selectedComponent: string;
+  componentTrail: string[];
+};
+
+export type SelectedArea = {
+  url: string;
+  pageTitle: string;
+  browser: string;
+  selector: string;
+  xpath: string;
+  tagName: string;
+  id: string;
+  classes: string[];
+  role: string;
+  ariaLabel: string;
+  textSnippet: string;
+  rect: Rect;
+  framework: FrameworkInfo | null;
+  viewport: Viewport;
+};
+
+export type CaptureRect = {
+  rect: Rect;
+  viewport: Viewport;
+  capturedAt: number;
+  url: string;
+};
+
+export type UserAction = {
+  id: string;
+  kind: "event" | "navigation";
+  type: string;
+  at: string;
+  target: string;
+  valueSnippet: string;
+  targetInfo: SelectedArea | null;
+  href?: string;
+  navigationKind?: string;
+};
+
+export type ConsoleEntry = {
+  level: "error" | "warn";
+  message: string;
+  at: string;
+};
+
+export type NetworkEntry = {
+  method: string;
+  url: string;
+  status: number;
+  at: string;
+  error?: string;
+};
+
+export type IssueDraft = {
+  repo: string;
+  summary: string;
+  currentBehavior: string;
+  expectedBehavior: string;
+  labels: string[];
+};
+
+export type TabState = {
+  selectedArea: SelectedArea | null;
+  captureRect: CaptureRect | null;
+  actions: UserAction[];
+  actionHistoryPast: UserAction[][];
+  actionHistoryFuture: UserAction[][];
+  consoleEntries: ConsoleEntry[];
+  networkEntries: NetworkEntry[];
+  screenshotDataUrl: string;
+  draft: IssueDraft;
+};
+
+export type HelperHealth = {
+  ok: boolean;
+  port: number;
+};
+
+export type HelperGitHubStatus = {
+  gh_installed: boolean;
+  authenticated: boolean;
+  login?: string;
+  name?: string;
+  error?: string;
+};
+
+export type HelperRepository = {
+  name_with_owner: string;
+};
+
+export type HelperState = {
+  reachable: boolean;
+  health: HelperHealth | null;
+  github: HelperGitHubStatus | null;
+  repositories: HelperRepository[];
+};
+
+export type RecordingState = {
+  stream: MediaStream | null;
+  recorder: MediaRecorder | null;
+  chunks: Blob[];
+  objectUrl: string;
+  canvas: HTMLCanvasElement | null;
+  context: CanvasRenderingContext2D | null;
+  framePending: Promise<void>;
+};
+
+export type IssueOptions = {
+  includeActions: boolean;
+};

--- a/packages/extension/src/sidepanel/components/HelperStatus.tsx
+++ b/packages/extension/src/sidepanel/components/HelperStatus.tsx
@@ -1,0 +1,82 @@
+import { currentHelper, statusMessage } from "../store/signals";
+import { refreshHelperState, startHelperLogin } from "../hooks/useHelper";
+
+export function HelperStatus() {
+  const helper = currentHelper.value;
+
+  const getStatusDotClass = () => {
+    if (!helper.reachable) return "helper-dot warn";
+    if (!helper.github?.gh_installed) return "helper-dot warn";
+    if (!helper.github?.authenticated) return "helper-dot warn";
+    return "helper-dot ok";
+  };
+
+  const getStatusText = () => {
+    if (!helper.reachable) return "Offline";
+    if (!helper.github?.gh_installed) return "gh Missing";
+    if (!helper.github?.authenticated) return "Login Required";
+    return "Ready";
+  };
+
+  const getSummaryText = () => {
+    if (!helper.reachable) return "Tossue Helper is offline";
+    if (!helper.github?.gh_installed) return "Helper is reachable, but gh is not installed";
+    if (!helper.github?.authenticated) return "GitHub CLI login is required";
+    return "Tossue Helper is ready";
+  };
+
+  const getDetailText = () => {
+    if (!helper.reachable) {
+      return "localhost helper に接続できません。`Copy` で手動投稿してください。";
+    }
+    if (!helper.github?.gh_installed) {
+      return "Tossue Helper は応答していますが、このマシンで `gh` コマンドが見つかりません。";
+    }
+    if (!helper.github?.authenticated) {
+      return helper.github?.error || "Run gh auth login.";
+    }
+    return `${helper.repositories.length} repositories loaded and ready for issue creation.`;
+  };
+
+  const getAccountText = () => {
+    if (!helper.github?.authenticated) return "Account: -";
+    const name = helper.github.name
+      ? `${helper.github.name} (@${helper.github.login})`
+      : `@${helper.github.login}`;
+    return `Account: ${name}`;
+  };
+
+  const endpointText = helper.health?.port
+    ? `Endpoint: 127.0.0.1:${helper.health.port}`
+    : "Endpoint: 127.0.0.1:47321";
+
+  const showLoginButton = helper.reachable && helper.github?.gh_installed && !helper.github?.authenticated;
+
+  return (
+    <details class="helper-section">
+      <summary id="helperSummary">
+        <span class={getStatusDotClass()} id="helperSummaryDot"></span>
+        <span id="helperSummaryText">{getStatusText()}</span>
+        {getSummaryText()}
+      </summary>
+      <div class="helper-detail">
+        <p id="helperDetail">{getDetailText()}</p>
+        <div class="helper-meta">
+          <span id="helperEndpoint">{endpointText}</span>
+          <span class={getStatusDotClass()} id="helperDot"></span>
+        </div>
+        <p id="helperAccount">{getAccountText()}</p>
+        <div class="helper-actions">
+          <button type="button" id="refreshHelper" onClick={refreshHelperState}>
+            Refresh Helper
+          </button>
+          {showLoginButton && (
+            <button type="button" id="loginHelper" onClick={startHelperLogin}>
+              Login via Helper
+            </button>
+          )}
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/packages/extension/src/sidepanel/components/LabelSelector.tsx
+++ b/packages/extension/src/sidepanel/components/LabelSelector.tsx
@@ -1,0 +1,107 @@
+import { useState } from "preact/hooks";
+import { labelPresets, selectedLabels } from "../store/signals";
+import { persistDraft, saveLabelPresets } from "../hooks/useTabState";
+
+const DEFAULT_LABEL_PRESETS = ["bug", "needs-triage", "diagnostics", "ui", "high-priority"];
+
+export function LabelSelector() {
+  const [customInput, setCustomInput] = useState("");
+
+  const toggleLabel = async (label: string) => {
+    const next = new Set(selectedLabels.value);
+    if (next.has(label)) {
+      next.delete(label);
+    } else {
+      next.add(label);
+    }
+    selectedLabels.value = next;
+    await persistDraft();
+  };
+
+  const addCustomLabel = async () => {
+    const label = customInput.trim();
+    if (!label) return;
+
+    if (!labelPresets.value.includes(label)) {
+      labelPresets.value = [...labelPresets.value, label];
+      await saveLabelPresets();
+    }
+
+    const next = new Set(selectedLabels.value);
+    next.add(label);
+    selectedLabels.value = next;
+    setCustomInput("");
+    await persistDraft();
+  };
+
+  const removeCustomLabel = async (label: string) => {
+    if (DEFAULT_LABEL_PRESETS.includes(label)) {
+      await toggleLabel(label);
+      return;
+    }
+
+    labelPresets.value = labelPresets.value.filter((item) => item !== label);
+    const next = new Set(selectedLabels.value);
+    next.delete(label);
+    selectedLabels.value = next;
+    await saveLabelPresets();
+    await persistDraft();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addCustomLabel();
+    }
+  };
+
+  return (
+    <fieldset class="label-fieldset">
+      <legend>Labels</legend>
+      <ul class="label-preset-list" id="labelPresetList">
+        {labelPresets.value.map((label) => {
+          const isSelected = selectedLabels.value.has(label);
+          const isCustom = !DEFAULT_LABEL_PRESETS.includes(label);
+          return (
+            <li key={label}>
+              <button
+                type="button"
+                class={`label-chip${isSelected ? " active" : ""}${isCustom ? " custom" : ""}`}
+                title={label}
+                onClick={() => toggleLabel(label)}
+              >
+                <span>{label}</span>
+                {isCustom && (
+                  <button
+                    type="button"
+                    class="label-chip-remove"
+                    title={`Remove ${label}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeCustomLabel(label);
+                    }}
+                  >
+                    ×
+                  </button>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      <div class="label-custom-row">
+        <input
+          type="text"
+          id="customLabelInput"
+          placeholder="Add custom label"
+          value={customInput}
+          onInput={(e) => setCustomInput((e.target as HTMLInputElement).value)}
+          onKeyDown={handleKeyDown}
+        />
+        <button type="button" id="addCustomLabel" onClick={addCustomLabel}>
+          Add
+        </button>
+      </div>
+    </fieldset>
+  );
+}

--- a/packages/extension/src/sidepanel/hooks/useHelper.ts
+++ b/packages/extension/src/sidepanel/hooks/useHelper.ts
@@ -1,0 +1,90 @@
+import { currentHelper, statusMessage } from "../store/signals";
+
+const HELPER_BASE_URL = "http://127.0.0.1:47321";
+
+export function useHelper() {
+  return {
+    refreshHelperState,
+    startHelperLogin,
+  };
+}
+
+export async function refreshHelperState() {
+  try {
+    const health = await helperGet("/health");
+    const github = await helperGet("/github/status");
+    let repositories: { name_with_owner: string }[] = [];
+
+    if (github.authenticated) {
+      const repoResult = await helperGet("/github/repositories");
+      repositories = repoResult.repositories || [];
+    }
+
+    currentHelper.value = {
+      reachable: Boolean(health.ok),
+      health,
+      github,
+      repositories,
+    };
+  } catch (error) {
+    currentHelper.value = {
+      reachable: false,
+      health: null,
+      github: null,
+      repositories: [],
+    };
+  }
+}
+
+export async function startHelperLogin() {
+  statusMessage.value = "Opening gh auth login in Tossue Helper...";
+
+  try {
+    const response = await helperPost("/github/login");
+    statusMessage.value = response.message;
+    await refreshHelperState();
+  } catch (error) {
+    statusMessage.value = (error as Error).message;
+  }
+}
+
+async function helperGet(path: string) {
+  const response = await fetch(`${HELPER_BASE_URL}${path}`);
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(payload.error || `Helper request failed: ${path}`);
+  }
+  return payload;
+}
+
+async function helperPost(path: string) {
+  const response = await fetch(`${HELPER_BASE_URL}${path}`, {
+    method: "POST",
+  });
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(payload.error || `Helper request failed: ${path}`);
+  }
+  return payload;
+}
+
+export async function createIssueViaHelper(
+  repo: string,
+  title: string,
+  body: string,
+  labels: string[]
+): Promise<{ issue_url: string }> {
+  const response = await fetch(`${HELPER_BASE_URL}/issues`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ repo, title, body, labels }),
+  });
+
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(payload.error || "Tossue Helper failed to create the issue.");
+  }
+  return payload;
+}

--- a/packages/extension/src/sidepanel/hooks/useTabState.ts
+++ b/packages/extension/src/sidepanel/hooks/useTabState.ts
@@ -1,0 +1,136 @@
+import { useEffect } from "preact/hooks";
+import {
+  activeTabId,
+  currentState,
+  labelPresets,
+  selectedLabels,
+  issueOptions,
+} from "../store/signals";
+import type { TabState, Message } from "../../shared/types";
+
+const LABEL_STORAGE_KEY = "labelPresets";
+const ISSUE_OPTIONS_STORAGE_KEY = "issueOptions";
+const DEFAULT_LABEL_PRESETS = ["bug", "needs-triage", "diagnostics", "ui", "high-priority"];
+
+export function useTabState() {
+  useEffect(() => {
+    bootstrap();
+
+    const handleMessage = (message: Message) => {
+      if (message.type === "STATE_UPDATED" && message.tabId === activeTabId.value) {
+        const nextState = message.state as TabState;
+        const shouldHydrate = !draftsEqual(currentState.value.draft, nextState?.draft);
+        currentState.value = nextState;
+        if (shouldHydrate) {
+          hydrateLabels(nextState.draft?.labels || []);
+        }
+      }
+    };
+
+    chrome.runtime.onMessage.addListener(handleMessage);
+    return () => chrome.runtime.onMessage.removeListener(handleMessage);
+  }, []);
+
+  return {
+    refreshState,
+    persistDraft,
+  };
+}
+
+async function bootstrap() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  activeTabId.value = tab?.id ?? null;
+  await Promise.all([loadLabelPresets(), loadIssueOptions()]);
+  await refreshState();
+}
+
+export async function refreshState() {
+  const response = await chrome.runtime.sendMessage({
+    type: "GET_ACTIVE_TAB_STATE",
+    tabId: activeTabId.value,
+  });
+
+  if (!response.ok) {
+    throw new Error(response.error);
+  }
+
+  currentState.value = response.state;
+  hydrateLabels(response.state.draft?.labels || []);
+}
+
+export async function persistDraft() {
+  const draft = {
+    repo: currentState.value.draft.repo,
+    summary: currentState.value.draft.summary,
+    currentBehavior: currentState.value.draft.currentBehavior,
+    expectedBehavior: currentState.value.draft.expectedBehavior,
+    labels: Array.from(selectedLabels.value),
+  };
+
+  await chrome.runtime.sendMessage({
+    type: "STORE_FORM",
+    tabId: activeTabId.value,
+    payload: draft,
+  });
+
+  currentState.value = { ...currentState.value, draft };
+}
+
+function draftsEqual(
+  left: TabState["draft"] | undefined,
+  right: TabState["draft"] | undefined
+): boolean {
+  const normalize = (draft: TabState["draft"] | undefined) =>
+    JSON.stringify({
+      repo: draft?.repo || "",
+      summary: draft?.summary || "",
+      currentBehavior: draft?.currentBehavior || "",
+      expectedBehavior: draft?.expectedBehavior || "",
+      labels: Array.isArray(draft?.labels) ? [...draft.labels].sort() : [],
+    });
+
+  return normalize(left) === normalize(right);
+}
+
+async function loadLabelPresets() {
+  const stored = await chrome.storage.local.get(LABEL_STORAGE_KEY);
+  const saved = Array.isArray(stored[LABEL_STORAGE_KEY]) ? stored[LABEL_STORAGE_KEY] : [];
+  labelPresets.value = Array.from(new Set([...DEFAULT_LABEL_PRESETS, ...saved.filter(Boolean)]));
+}
+
+async function loadIssueOptions() {
+  const stored = await chrome.storage.local.get(ISSUE_OPTIONS_STORAGE_KEY);
+  const saved = stored[ISSUE_OPTIONS_STORAGE_KEY];
+  issueOptions.value = {
+    includeActions: saved?.includeActions !== false,
+  };
+}
+
+function hydrateLabels(labelsValue: string[] | string) {
+  const labels = Array.isArray(labelsValue)
+    ? labelsValue
+    : String(labelsValue || "")
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean);
+
+  for (const label of labels) {
+    if (!labelPresets.value.includes(label)) {
+      labelPresets.value = [...labelPresets.value, label];
+    }
+  }
+
+  selectedLabels.value = new Set(labels);
+}
+
+export async function saveLabelPresets() {
+  await chrome.storage.local.set({
+    [LABEL_STORAGE_KEY]: labelPresets.value,
+  });
+}
+
+export async function saveIssueOptions() {
+  await chrome.storage.local.set({
+    [ISSUE_OPTIONS_STORAGE_KEY]: issueOptions.value,
+  });
+}

--- a/packages/extension/src/sidepanel/store/signals.ts
+++ b/packages/extension/src/sidepanel/store/signals.ts
@@ -1,0 +1,73 @@
+import { signal, computed } from "@preact/signals";
+import type {
+  TabState,
+  HelperState,
+  RecordingState,
+  IssueOptions,
+} from "../../shared/types";
+
+const DEFAULT_LABEL_PRESETS = ["bug", "needs-triage", "diagnostics", "ui", "high-priority"];
+
+function createEmptyState(): TabState {
+  return {
+    selectedArea: null,
+    captureRect: null,
+    actions: [],
+    actionHistoryPast: [],
+    actionHistoryFuture: [],
+    consoleEntries: [],
+    networkEntries: [],
+    screenshotDataUrl: "",
+    draft: {
+      repo: "",
+      summary: "",
+      currentBehavior: "",
+      expectedBehavior: "",
+      labels: [],
+    },
+  };
+}
+
+export const activeTabId = signal<number | null>(null);
+export const currentState = signal<TabState>(createEmptyState());
+export const currentHelper = signal<HelperState>({
+  reachable: false,
+  health: null,
+  github: null,
+  repositories: [],
+});
+
+export const recordingState = signal<RecordingState>({
+  stream: null,
+  recorder: null,
+  chunks: [],
+  objectUrl: "",
+  canvas: null,
+  context: null,
+  framePending: Promise.resolve(),
+});
+
+export const issueOptions = signal<IssueOptions>({
+  includeActions: true,
+});
+
+export const labelPresets = signal<string[]>([...DEFAULT_LABEL_PRESETS]);
+export const selectedLabels = signal<Set<string>>(new Set());
+export const statusMessage = signal<string>("");
+export const captureStatusMessage = signal<string>("");
+
+export const canUndo = computed(() => (currentState.value.actionHistoryPast?.length ?? 0) > 0);
+export const canRedo = computed(() => (currentState.value.actionHistoryFuture?.length ?? 0) > 0);
+export const hasActions = computed(() => (currentState.value.actions?.length ?? 0) > 0);
+
+export const canCreateIssue = computed(() =>
+  Boolean(
+    currentHelper.value.reachable &&
+      currentHelper.value.github?.gh_installed &&
+      currentHelper.value.github?.authenticated
+  )
+);
+
+export const issueTitle = computed(() =>
+  currentState.value.draft.summary.split("\n")[0].trim().slice(0, 80) || "Bug report"
+);

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     port: 5173,
     strictPort: true,
     hmr: {
+      host: "localhost",
       port: 5173,
     },
   },


### PR DESCRIPTION
## Summary

Phase 2 & 3 の部分的実装:

### Phase 2: TypeScript 型定義
- `src/shared/types/` に共有型定義を作成
  - `state.ts`: TabState, SelectedArea, UserAction など
  - `messages.ts`: Message types
  - `content.ts`: Content script types
- `background/index.ts` に完全な型付け

### Phase 3: Preact 基盤
- `@preact/signals` を導入
- Signal ベースのストア (`store/signals.ts`)
- カスタムフック: `useTabState`, `useHelper`
- コンポーネント: `HelperStatus`, `LabelSelector`

## Related Issues
Closes #6

## Note
Phase 3 の残り（sidepanel の完全な Preact 化）と Phase 4（DevTools Panel）は後続の PR で実装します。この PR では基盤となる型定義とコンポーネント構造を整備しています。

## Test Plan
- [ ] `npm install`
- [ ] `npm run build:extension` が成功する
- [ ] 既存の機能が引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)