### PR TITLE
feat(ui): Unify Button and Card component styles (#15)

### DIFF
--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -1,0 +1,178 @@
+# UI Components Specification
+
+共通UIコンポーネントの仕様を定義する。
+
+## 概要
+
+サイドパネル全体で一貫したデザインシステムを構築するため、`Button` と `Card` を共通コンポーネントとして提供する。スタイリングには UnoCSS ユーティリティを使用する。
+
+## デザイントークン
+
+`packages/extension/uno.config.ts` で定義されたテーマカラーを使用する：
+
+| UnoCSS Class | CSS Variable | 用途 |
+|--------------|--------------|------|
+| `bg-bg` | `--bg` | ページ背景 |
+| `bg-surface` | `--surface` | カード・入力欄背景 |
+| `bg-surface-strong` | `--surface-strong` | 強調サーフェス |
+| `border-border` | `--border` | ボーダー色 |
+| `text-text` | `--text` | 主要テキスト |
+| `text-muted` | `--muted` | 補助テキスト |
+| `bg-accent` | `--accent` | プライマリアクション |
+| `bg-accent-soft` | `--accent-soft` | セカンダリアクション背景 |
+
+## Button コンポーネント
+
+### バリアント
+
+| バリアント | 用途 | UnoCSS クラス |
+|-----------|------|---------------|
+| `primary` | 主要アクション（Create Issue） | `bg-accent text-white` |
+| `secondary` | 副次的アクション（Refresh） | `bg-accent-soft text-text` |
+| `ghost` | 控えめなアクション（Undo, Delete） | `bg-transparent hover:bg-black/8` |
+
+### サイズ
+
+| サイズ | 用途 | UnoCSS クラス |
+|-------|------|---------------|
+| `md`（デフォルト） | 標準ボタン | `px-3.5 py-2.5` |
+| `sm` | コンパクトなボタン | `px-2.5 py-1.5 text-xs` |
+
+### アイコンボタン
+
+`iconOnly` プロパティで正方形のアイコンボタンになる。
+
+| サイズ | UnoCSS クラス |
+|-------|---------------|
+| `md` | `w-7 h-7 p-0` |
+| `sm` | `w-5.5 h-5.5 p-0` |
+
+### 共通スタイル
+
+```
+border-0 rounded-full cursor-pointer font-bold disabled:opacity-50 disabled:cursor-default
+```
+
+### Props
+
+```typescript
+interface ButtonProps {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  size?: 'md' | 'sm';
+  iconOnly?: boolean;
+  disabled?: boolean;
+  children: ComponentChildren;
+  onClick?: () => void;
+  type?: 'button' | 'submit';
+  id?: string;
+  class?: string;
+  'aria-label'?: string;
+}
+```
+
+### 使用例
+
+```tsx
+// Primary button (default)
+<Button onClick={handleCreate}>Create Issue</Button>
+
+// Secondary button
+<Button variant="secondary" onClick={handleRefresh}>Refresh</Button>
+
+// Ghost icon button
+<Button variant="ghost" iconOnly aria-label="Undo" onClick={handleUndo}>←</Button>
+
+// Small secondary button
+<Button variant="secondary" size="sm" onClick={handleAdd}>Add</Button>
+```
+
+## Card コンポーネント
+
+### バリアント
+
+| バリアント | 用途 | UnoCSS クラス |
+|-----------|------|---------------|
+| `default` | セクションコンテナ | `bg-surface/92 rounded-[14px] shadow-[0_8px_30px_rgba(62,42,18,0.06)]` |
+| `nested` | カード内のサブセクション | `bg-surface-strong/68 rounded-xl shadow-none` |
+
+### 共通スタイル
+
+```
+grid gap-3 p-3.5 border border-border
+```
+
+### Props
+
+```typescript
+interface CardProps {
+  variant?: 'default' | 'nested';
+  children: ComponentChildren;
+  class?: string;
+}
+```
+
+### 使用例
+
+```tsx
+// Default card for sections
+<Card>
+  <div class="flex items-center justify-between gap-2">
+    <h2>Structured Report</h2>
+  </div>
+  <div class="grid gap-2.5 grid-cols-2">
+    {/* content */}
+  </div>
+</Card>
+
+// Nested card within a section
+<Card variant="nested">
+  <h3>Screenshot</h3>
+  <Button variant="secondary">Capture</Button>
+</Card>
+```
+
+## 移行方針
+
+### 現状のボタン実装
+
+| 現在のパターン | 移行後 |
+|---------------|--------|
+| `<button>` | `<Button>` |
+| `<button class="secondary">` | `<Button variant="secondary">` |
+| `<button class="secondary icon-only">` | `<Button variant="secondary" iconOnly>` |
+| `<button class="action-icon-button">` | `<Button variant="ghost" size="sm" iconOnly>` |
+
+### 移行対象外
+
+- `.label-chip`: トグルボタンとして独自の振る舞いがあるため、別途 `Chip` コンポーネントとして検討
+- `.action-cutline`: 特殊なレイアウト要件があるため現状維持
+- `.preview-close`: オーバーレイ用の特殊配置のため現状維持
+
+### 現状のカード実装
+
+| 現在のパターン | 移行後 |
+|---------------|--------|
+| `<section class="card">` | `<Card>` |
+| `<section class="capture-tool-card">` | `<Card variant="nested">` |
+
+## ファイル構成
+
+```
+packages/extension/src/sidepanel/components/
+├── ui/
+│   ├── Button.tsx
+│   └── Card.tsx
+```
+
+スタイルは各コンポーネント内で UnoCSS ユーティリティクラスとして定義する（CSS Modules は使用しない）。
+
+## CSS 削除対象
+
+コンポーネント移行後、`global.css` から以下のスタイルを削除する：
+
+- `button` 基本スタイル（456-464行目）
+- `button.secondary`（466-469行目）
+- `button.icon-only`（471-477行目）
+- `button:disabled`（479-482行目）
+- `.card`（81-89行目）
+- `.capture-tool-card`（192-199行目）

--- a/packages/extension/src/sidepanel/App.tsx
+++ b/packages/extension/src/sidepanel/App.tsx
@@ -2,6 +2,7 @@ import { useTabState, refreshState } from "./hooks/useTabState";
 import { useRecording } from "./hooks/useRecording";
 import { useCapture } from "./hooks/useCapture";
 import { useDevtoolsStatus } from "./hooks/useDevtoolsStatus";
+import { Button, Card } from "./components/ui";
 import { HelperStatus } from "./components/HelperStatus";
 import { DevToolsStatus } from "./components/DevToolsStatus";
 import { ReportForm } from "./components/ReportForm";
@@ -23,15 +24,15 @@ export function App() {
           <p class="eyebrow">AI-ready issue composer</p>
           <h1>Tossue</h1>
         </div>
-        <button id="refreshState" class="secondary" onClick={refreshState}>
+        <Button id="refreshState" variant="secondary" onClick={refreshState}>
           Refresh
-        </button>
+        </Button>
       </header>
 
-      <section class="card grid">
+      <Card class="grid">
         <HelperStatus />
         <DevToolsStatus />
-      </section>
+      </Card>
 
       <ReportForm />
       <CaptureTools />

--- a/packages/extension/src/sidepanel/components/ActionTimeline.tsx
+++ b/packages/extension/src/sidepanel/components/ActionTimeline.tsx
@@ -20,6 +20,7 @@ import {
 } from "../hooks/useActions";
 import { highlightArea, clearHighlight } from "../hooks/useCapture";
 import { formatActionIndex, formatActionTitle, formatActionDetail } from "../utils/format";
+import { Button, Card } from "./ui";
 
 export function ActionTimeline() {
   const timeline = useComputed(() => unifiedTimeline.value);
@@ -53,7 +54,7 @@ export function ActionTimeline() {
   };
 
   return (
-    <section class="card">
+    <Card>
       <div class="section-title-row">
         <h2>Timeline</h2>
         <div class="button-row">
@@ -66,36 +67,36 @@ export function ActionTimeline() {
             />
             <span>Use in issue</span>
           </label>
-          <button
+          <Button
             id="undoActions"
-            class="secondary icon-only"
-            type="button"
+            variant="secondary"
+            iconOnly
             aria-label="Undo"
             disabled={!canUndo.value}
             onClick={undoActions}
           >
             ←
-          </button>
-          <button
+          </Button>
+          <Button
             id="redoActions"
-            class="secondary icon-only"
-            type="button"
+            variant="secondary"
+            iconOnly
             aria-label="Redo"
             disabled={!canRedo.value}
             onClick={redoActions}
           >
             →
-          </button>
-          <button
+          </Button>
+          <Button
             id="clearActions"
-            class="secondary icon-only"
-            type="button"
+            variant="secondary"
+            iconOnly
             aria-label="Clear all"
             disabled={!hasTimelineEntries.value}
             onClick={clearActions}
           >
             ⊘
-          </button>
+          </Button>
         </div>
       </div>
       <div
@@ -117,7 +118,7 @@ export function ActionTimeline() {
           />
         ))}
       </div>
-    </section>
+    </Card>
   );
 }
 
@@ -223,15 +224,15 @@ function ActionRow({ action, index, onHover, onLeave, onDelete, onTrimBefore }: 
           <strong class="action-row-title">{label}</strong>
           {detail && <span class="action-row-detail">{detail}</span>}
         </div>
-        <button
-          class="action-icon-button"
-          type="button"
-          data-action-command="delete"
+        <Button
+          variant="ghost"
+          size="sm"
+          iconOnly
           aria-label="Delete action"
           onClick={() => onDelete(action.id)}
         >
           ×
-        </button>
+        </Button>
       </article>
     </>
   );
@@ -270,15 +271,15 @@ function ConsoleRow({ entry, index, onDelete, onTrimBefore }: ConsoleRowProps) {
           </strong>
           <span class="action-row-detail">{entry.message.slice(0, 100)}</span>
         </div>
-        <button
-          class="action-icon-button"
-          type="button"
-          data-action-command="delete"
+        <Button
+          variant="ghost"
+          size="sm"
+          iconOnly
           aria-label="Delete entry"
           onClick={() => onDelete(entry.id)}
         >
           ×
-        </button>
+        </Button>
       </article>
     </>
   );
@@ -326,15 +327,15 @@ function NetworkRow({ entry, index, onDelete, onTrimBefore }: NetworkRowProps) {
           </strong>
           <span class="action-row-detail">{displayUrl.slice(0, 80)}</span>
         </div>
-        <button
-          class="action-icon-button"
-          type="button"
-          data-action-command="delete"
+        <Button
+          variant="ghost"
+          size="sm"
+          iconOnly
           aria-label="Delete entry"
           onClick={() => onDelete(entry.id)}
         >
           ×
-        </button>
+        </Button>
       </article>
     </>
   );

--- a/packages/extension/src/sidepanel/components/CaptureTools.tsx
+++ b/packages/extension/src/sidepanel/components/CaptureTools.tsx
@@ -10,6 +10,7 @@ import {
 import { startAreaPicker, startCaptureMode, clearScreenshotPreview, highlightArea, clearHighlight } from "../hooks/useCapture";
 import { toggleRecording, clearRecordingPreview } from "../hooks/useRecording";
 import { formatSelectedElement } from "../utils/format";
+import { Button, Card } from "./ui";
 
 export function CaptureTools() {
   const state = useComputed(() => currentState.value);
@@ -29,17 +30,17 @@ export function CaptureTools() {
   };
 
   return (
-    <section class="card">
+    <Card>
       <div class="section-title-row">
         <h2>Captured Context</h2>
       </div>
       <div class="capture-tool-grid">
-        <section class="capture-tool-card">
+        <Card variant="nested">
           <div class="capture-tool-head">
             <h3>Select Area</h3>
-            <button id="selectArea" class="secondary" onClick={startAreaPicker}>
+            <Button id="selectArea" variant="secondary" onClick={startAreaPicker}>
               {selectAreaButtonText.value}
-            </button>
+            </Button>
           </div>
           <div
             id="areaSummary"
@@ -56,14 +57,14 @@ export function CaptureTools() {
               "No area selected."
             )}
           </div>
-        </section>
+        </Card>
 
-        <section class="capture-tool-card">
+        <Card variant="nested">
           <div class="capture-tool-head">
             <h3>Capture Image</h3>
-            <button id="captureScreenshot" class="secondary" onClick={startCaptureMode}>
+            <Button id="captureScreenshot" variant="secondary" onClick={startCaptureMode}>
               {captureButtonText.value}
-            </button>
+            </Button>
           </div>
           <div id="screenshotWrap" class={`preview-wrap ${hasScreenshot.value ? "" : "hidden"}`}>
             <button
@@ -82,14 +83,14 @@ export function CaptureTools() {
               src={state.value.screenshotDataUrl}
             />
           </div>
-        </section>
+        </Card>
 
-        <section class="capture-tool-card">
+        <Card variant="nested">
           <div class="capture-tool-head">
             <h3>Screen Recording</h3>
-            <button id="toggleRecording" class="secondary" onClick={toggleRecording}>
+            <Button id="toggleRecording" variant="secondary" onClick={toggleRecording}>
               {recordingButtonText.value}
-            </button>
+            </Button>
           </div>
           <div id="recordingWrap" class={`preview-wrap ${hasRecording.value ? "" : "hidden"}`}>
             <button
@@ -109,12 +110,12 @@ export function CaptureTools() {
               src={recording.value.objectUrl}
             />
           </div>
-        </section>
+        </Card>
       </div>
       <p id="captureStatus" class="status">
         {captureStatusMessage.value || "`Select Area` は DOM 要素選択、`Start Capture` は画面上の矩形キャプチャ、`Start Recording` は画面録画です。"}
       </p>
-    </section>
+    </Card>
   );
 }
 

--- a/packages/extension/src/sidepanel/components/IssueCreator.tsx
+++ b/packages/extension/src/sidepanel/components/IssueCreator.tsx
@@ -12,6 +12,7 @@ import {
 import { createIssueViaHelper } from "../hooks/useHelper";
 import { sanitizeFilename } from "../utils/format";
 import { blobUrlToDataUrl } from "../utils/image";
+import { Button, Card } from "./ui";
 
 export function IssueCreator() {
   const helper = useComputed(() => currentHelper.value);
@@ -88,16 +89,16 @@ export function IssueCreator() {
   };
 
   return (
-    <section class="card">
+    <Card>
       <div class="section-title-row">
         <h2>Create GitHub Issue</h2>
-        <button
+        <Button
           id="createIssue"
           disabled={!canCreateIssue.value}
           onClick={handleCreateIssue}
         >
           Create Issue
-        </button>
+        </Button>
       </div>
       <p id="createIssueHint" class="status">
         {getHintText()}
@@ -105,7 +106,7 @@ export function IssueCreator() {
       <p id="submitStatus" class="status">
         {status.value}
       </p>
-    </section>
+    </Card>
   );
 }
 

--- a/packages/extension/src/sidepanel/components/MarkdownPreview.tsx
+++ b/packages/extension/src/sidepanel/components/MarkdownPreview.tsx
@@ -1,4 +1,5 @@
 import { issueTitle, markdown, statusMessage } from "../store/signals";
+import { Button, Card } from "./ui";
 
 export function MarkdownPreview() {
   const handleCopy = async () => {
@@ -8,13 +9,13 @@ export function MarkdownPreview() {
 
   // Use signals directly in JSX - @preact/signals handles reactivity automatically
   return (
-    <section class="card">
+    <Card>
       <div class="section-title-row">
         <h2>Markdown Preview</h2>
         <div class="button-row">
-          <button id="copyMarkdown" class="secondary" onClick={handleCopy}>
+          <Button id="copyMarkdown" variant="secondary" onClick={handleCopy}>
             Copy
-          </button>
+          </Button>
         </div>
       </div>
       <label>
@@ -28,6 +29,6 @@ export function MarkdownPreview() {
         value={markdown}
         readOnly
       />
-    </section>
+    </Card>
   );
 }

--- a/packages/extension/src/sidepanel/components/ReportForm.tsx
+++ b/packages/extension/src/sidepanel/components/ReportForm.tsx
@@ -1,6 +1,7 @@
 import { useComputed } from "@preact/signals";
 import { currentState, currentHelper, selectedLabels } from "../store/signals";
 import { persistDraft } from "../hooks/useTabState";
+import { Card } from "./ui";
 import { LabelSelector } from "./LabelSelector";
 
 export function ReportForm() {
@@ -22,7 +23,7 @@ export function ReportForm() {
 
   return (
     <>
-      <section class="card grid">
+      <Card class="grid">
         <label>
           <span>GitHub Repository</span>
           <input
@@ -38,9 +39,9 @@ export function ReportForm() {
             ))}
           </datalist>
         </label>
-      </section>
+      </Card>
 
-      <section class="card">
+      <Card>
         <div class="section-title-row">
           <h2>Structured Report</h2>
         </div>
@@ -74,7 +75,7 @@ export function ReportForm() {
           </label>
           <LabelSelector />
         </div>
-      </section>
+      </Card>
     </>
   );
 }

--- a/packages/extension/src/sidepanel/components/ui/Button.tsx
+++ b/packages/extension/src/sidepanel/components/ui/Button.tsx
@@ -1,0 +1,65 @@
+import type { ComponentChildren, JSX } from "preact";
+
+export interface ButtonProps {
+  variant?: "primary" | "secondary" | "ghost";
+  size?: "md" | "sm";
+  iconOnly?: boolean;
+  disabled?: boolean;
+  children: ComponentChildren;
+  onClick?: () => void;
+  type?: "button" | "submit";
+  id?: string;
+  class?: string;
+  "aria-label"?: string;
+}
+
+const variantClasses = {
+  primary: "bg-accent text-white",
+  secondary: "bg-accent-soft text-text",
+  ghost: "bg-transparent text-text hover:bg-black/8",
+} as const;
+
+const sizeClasses = {
+  md: "px-3.5 py-2.5",
+  sm: "px-2.5 py-1.5 text-xs",
+} as const;
+
+const iconSizeClasses = {
+  md: "w-7 h-7 p-0 text-[15px]",
+  sm: "w-5.5 h-5.5 p-0 text-[13px]",
+} as const;
+
+export function Button({
+  variant = "primary",
+  size = "md",
+  iconOnly = false,
+  disabled = false,
+  children,
+  onClick,
+  type = "button",
+  id,
+  class: className,
+  "aria-label": ariaLabel,
+}: ButtonProps): JSX.Element {
+  const baseClasses =
+    "border-0 rounded-full cursor-pointer font-bold leading-none disabled:opacity-50 disabled:cursor-default";
+  const variantClass = variantClasses[variant];
+  const sizeClass = iconOnly ? iconSizeClasses[size] : sizeClasses[size];
+
+  const classes = [baseClasses, variantClass, sizeClass, className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      type={type}
+      id={id}
+      class={classes}
+      disabled={disabled}
+      onClick={onClick}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/extension/src/sidepanel/components/ui/Card.tsx
+++ b/packages/extension/src/sidepanel/components/ui/Card.tsx
@@ -1,0 +1,28 @@
+import type { ComponentChildren, JSX } from "preact";
+
+export interface CardProps {
+  variant?: "default" | "nested";
+  children: ComponentChildren;
+  class?: string;
+}
+
+const variantClasses = {
+  default:
+    "p-3.5 bg-surface/92 rounded-[14px] shadow-[0_8px_30px_rgba(62,42,18,0.06)]",
+  nested: "p-3 bg-surface-strong/68 rounded-xl",
+} as const;
+
+export function Card({
+  variant = "default",
+  children,
+  class: className,
+}: CardProps): JSX.Element {
+  const baseClasses = "grid gap-3 border border-border";
+  const variantClass = variantClasses[variant];
+
+  const classes = [baseClasses, variantClass, className]
+    .filter(Boolean)
+    .join(" ");
+
+  return <section class={classes}>{children}</section>;
+}

--- a/packages/extension/src/sidepanel/components/ui/index.ts
+++ b/packages/extension/src/sidepanel/components/ui/index.ts
@@ -1,0 +1,4 @@
+export { Button } from "./Button";
+export type { ButtonProps } from "./Button";
+export { Card } from "./Card";
+export type { CardProps } from "./Card";

--- a/packages/extension/src/styles/global.css
+++ b/packages/extension/src/styles/global.css
@@ -78,16 +78,6 @@ h3 {
   font-size: 14px;
 }
 
-.card {
-  display: grid;
-  gap: 12px;
-  padding: 14px;
-  background: rgba(255, 252, 246, 0.92);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  box-shadow: 0 8px 30px rgba(62, 42, 18, 0.06);
-}
-
 .auth-toolbar {
   display: grid;
   gap: 10px;
@@ -189,15 +179,6 @@ h3 {
   gap: 10px;
 }
 
-.capture-tool-card {
-  display: grid;
-  gap: 8px;
-  padding: 12px;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  background: rgba(255, 247, 234, 0.68);
-}
-
 .capture-tool-head {
   display: flex;
   align-items: center;
@@ -281,17 +262,6 @@ h3 {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.action-icon-button {
-  width: 22px;
-  height: 22px;
-  padding: 0;
-  border-radius: 999px;
-  background: rgba(27, 26, 23, 0.08);
-  color: var(--text);
-  font-size: 13px;
-  line-height: 1;
 }
 
 .action-cutline {
@@ -451,34 +421,6 @@ textarea {
 
 textarea {
   resize: vertical;
-}
-
-button {
-  border: 0;
-  border-radius: 999px;
-  background: var(--accent);
-  color: white;
-  padding: 10px 14px;
-  cursor: pointer;
-  font-weight: 700;
-}
-
-button.secondary {
-  background: var(--accent-soft);
-  color: var(--text);
-}
-
-button.icon-only {
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  font-size: 15px;
-  line-height: 1;
-}
-
-button:disabled {
-  opacity: 0.5;
-  cursor: default;
 }
 
 .summary-box,


### PR DESCRIPTION
## Summary

- Add reusable `Button` and `Card` components using UnoCSS utilities
- Replace CSS class-based styling with component-based approach
- `Button` supports `primary` / `secondary` / `ghost` variants with `md` / `sm` sizes
- `Card` supports `default` / `nested` variants
- Remove redundant CSS (~1KB reduction in global.css)

## Changes

- New: `packages/extension/src/sidepanel/components/ui/Button.tsx`
- New: `packages/extension/src/sidepanel/components/ui/Card.tsx`
- New: `docs/ui-components.md` - Component specification
- Updated: App.tsx, ReportForm, CaptureTools, ActionTimeline, MarkdownPreview, IssueCreator
- Cleaned up: `global.css` (removed .card, .capture-tool-card, button styles)

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] All buttons render correctly with expected variants
- [ ] All cards render correctly with consistent styling
- [ ] Sidepanel visual appearance matches previous design

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)