### PR TITLE
feat(ui): ラベル選択UIの改善

### DIFF
--- a/packages/extension/src/styles/global.css
+++ b/packages/extension/src/styles/global.css
@@ -422,8 +422,15 @@ label span {
 
 .label-add-row {
   display: flex;
-  flex-wrap: wrap;
   gap: 8px;
+  align-items: center;
+}
+
+.label-add-row input {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 10px;
+  font-size: 12px;
 }
 
 input,


### PR DESCRIPTION
## Summary

- Helper API に `GET /github/repos/:owner/:repo/labels` エンドポイントを追加
- リポジトリ選択時に GitHub からラベル一覧を取得・表示
- Helper 未接続時・リポジトリ未選択時は適切なメッセージを表示
- ラベルチップをコンパクト化し、色をアンダーラインで表現
- カスタムラベル追加入力欄とボタンを1行にレイアウト

## Test plan

- [ ] Helper 未接続時に「Connect to Tossue Helper to use labels」が表示される
- [ ] Helper 接続後、リポジトリ未選択時に「Select a repository to see available labels」が表示される
- [ ] リポジトリ選択後、そのリポジトリのラベル一覧が表示される
- [ ] ラベルをクリックで選択/解除できる
- [ ] カスタムラベルを追加できる

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)