### PR TITLE
feat: コンポーネント情報をタイムラインに表示 (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ target/
 dist/
 build/
 .vite/
+.next/
+.nuxt/
+next-env.d.ts
 
 # OS files
 .DS_Store

--- a/docs/component-detection.md
+++ b/docs/component-detection.md
@@ -1,0 +1,141 @@
+# Component Detection Specification
+
+フレームワークコンポーネント情報を要素メタデータに追加する機能の仕様。
+
+## 概要
+
+ブラウザ上でクリック・操作された要素に対して、React / Vue などのフレームワークコンポーネント情報を自動検出し、Issue 報告に含める。
+
+## 対応フレームワーク
+
+| フレームワーク | 検出方法 | 対応状況 |
+|---------------|---------|---------|
+| React | React Fiber (`__reactFiber$*`) | ✅ 実装済み |
+| Vue 3 | `__vueParentComponent` | ✅ 実装済み |
+| Next.js | React Fiber 経由 | ✅ 実装済み |
+| Nuxt 3 | Vue 3 経由 | ✅ 実装済み |
+| DOM フォールバック | data-testid, aria-label, tag.class | ✅ 実装済み |
+
+## データ構造
+
+```ts
+type FrameworkInfo = {
+  framework: "React" | "Vue" | "DOM";
+  selectedComponent: string;        // 直近のコンポーネント名
+  componentTrail: string[];         // 親コンポーネントの階層（最大6件）
+  filePath?: string;                // ソースファイルパス（将来実装）
+};
+```
+
+## 検出ロジック
+
+### React / Next.js
+
+1. クリック要素から親方向に DOM ツリーを走査
+2. `__reactFiber$*` または `__reactInternalInstance$*` プロパティを検索
+3. Fiber ノードから `elementType.displayName` または `elementType.name` を取得
+4. 親 Fiber を辿って componentTrail を構築（最大6階層）
+
+```ts
+function detectReactInfo(element: Element): FrameworkInfo | null {
+  let current = element;
+  while (current) {
+    const fiber = findReactFiber(current);
+    if (fiber) {
+      const trail = buildReactComponentTrail(fiber);
+      return {
+        framework: "React",
+        selectedComponent: trail[0] || "",
+        componentTrail: trail.slice(0, 6)
+      };
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+```
+
+### Vue 3 / Nuxt 3
+
+1. クリック要素から親方向に DOM ツリーを走査
+2. `__vueParentComponent` プロパティを検索
+3. Vue instance から `type.name` または `type.__name` を取得
+4. 親 instance を辿って componentTrail を構築（最大6階層）
+
+```ts
+function detectVueInfo(element: Element): FrameworkInfo | null {
+  let current = element;
+  while (current) {
+    const instance = current.__vueParentComponent;
+    if (instance) {
+      const trail = buildVueComponentTrail(instance);
+      return {
+        framework: "Vue",
+        selectedComponent: trail[0] || "",
+        componentTrail: trail.slice(0, 6)
+      };
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+```
+
+### DOM フォールバック
+
+フレームワークが検出できない場合、DOM 属性から人間が理解しやすい情報を抽出:
+
+1. `data-testid` 属性
+2. `aria-label` 属性（40文字以内）
+3. `tag.class` 形式（クラス名は最大2つ）
+
+## UI 表示
+
+### Selected Area セクション
+
+```
+┌─────────────────────────────────────┐
+│ 🎯 HeaderComponent                  │ ← コンポーネント名（優先表示）
+│    React                            │ ← フレームワークラベル
+│    header#main-header.sticky        │ ← HTML 要素（サブテキスト）
+└─────────────────────────────────────┘
+```
+
+### Recent Actions タイムライン
+
+```
+┌─────────────────────────────────────┐
+│ 10:30:15  click                     │
+│           SubmitButton              │ ← コンポーネント名
+│           "送信"                    │ ← テキストスニペット
+└─────────────────────────────────────┘
+```
+
+### Markdown 出力
+
+```markdown
+### Selected Area
+
+- URL: https://example.com/page
+- Element: header#main-header.sticky
+- Framework: React
+- Component: HeaderComponent
+- Component Tree: HeaderComponent > Layout > App
+
+### Recent Actions
+
+1. click | SubmitButton [React] | "送信"
+2. input | EmailInput [React] | "user@..."
+```
+
+## 制限事項
+
+- Production ビルドでは minify によりコンポーネント名が失われる場合がある
+- SSR 初期レンダリング直後は Fiber/instance がアタッチされていない場合がある
+- iframe 内の要素は検出対象外
+
+## 将来の拡張（MVP 外）
+
+- ソースマップからのファイルパス取得
+- Svelte / SolidJS 対応
+- コンポーネント props の収集

--- a/docs/product-overview.md
+++ b/docs/product-overview.md
@@ -31,7 +31,6 @@ MVP では以下だけを確実に実装する。
 
 MVP でやらないもの。
 
-- 高精度な React/Vue コンポーネント名の取得
 - 長時間の動画録画
 - 自動で再現手順を完全生成する機能
 - Safari 固有実装の先行対応
@@ -173,6 +172,7 @@ host permissions:
 - CSS selector candidate
 - XPath candidate
 - bounding rect
+- フレームワークコンポーネント情報（React / Vue 対応）
 
 ### `sidepanel app`
 
@@ -222,6 +222,14 @@ type SelectedArea = {
   ariaLabel?: string;
   textSnippet?: string;
   rect: { x: number; y: number; width: number; height: number };
+  framework?: FrameworkInfo;
+};
+
+type FrameworkInfo = {
+  framework: "React" | "Vue" | "DOM";
+  selectedComponent: string;
+  componentTrail: string[];
+  filePath?: string; // ソースマップから取得（開発環境のみ）
 };
 
 type UserAction = {

--- a/packages/demo-sites/next/app/components/Card.tsx
+++ b/packages/demo-sites/next/app/components/Card.tsx
@@ -1,0 +1,13 @@
+type CardProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+export function Card({ title, children }: CardProps) {
+  return (
+    <section className="demo-card">
+      <h2 className="demo-card-title">{title}</h2>
+      <div className="demo-card-content">{children}</div>
+    </section>
+  );
+}

--- a/packages/demo-sites/next/app/components/FormInput.tsx
+++ b/packages/demo-sites/next/app/components/FormInput.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+type FormInputProps = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+};
+
+export function FormInput({ label, value, onChange, placeholder }: FormInputProps) {
+  return (
+    <div className="form-input">
+      <label className="form-label">{label}</label>
+      <input
+        type="text"
+        className="form-field"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}

--- a/packages/demo-sites/next/app/components/SubmitButton.tsx
+++ b/packages/demo-sites/next/app/components/SubmitButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+type SubmitButtonProps = {
+  label: string;
+  onClick: () => void;
+  variant?: "primary" | "secondary" | "danger";
+};
+
+export function SubmitButton({ label, onClick, variant = "primary" }: SubmitButtonProps) {
+  return (
+    <button
+      type="button"
+      className={`submit-button submit-button--${variant}`}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/packages/demo-sites/next/app/components/index.ts
+++ b/packages/demo-sites/next/app/components/index.ts
@@ -1,0 +1,3 @@
+export { FormInput } from "./FormInput";
+export { SubmitButton } from "./SubmitButton";
+export { Card } from "./Card";

--- a/packages/demo-sites/next/app/globals.css
+++ b/packages/demo-sites/next/app/globals.css
@@ -130,3 +130,46 @@ button.danger:hover {
   padding-left: 1rem;
   border-left: 2px solid #0066cc;
 }
+
+.form-demo {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.375rem;
+}
+
+.form-field label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #333;
+}
+
+.form-field input {
+  padding: 0.625rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  background: #fff;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.form-field input:focus {
+  outline: none;
+  border-color: #0066cc;
+  box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.1);
+}
+
+.form-field input::placeholder {
+  color: #999;
+}
+
+button.secondary {
+  background: #6c757d;
+}
+
+button.secondary:hover {
+  background: #5a6268;
+}

--- a/packages/demo-sites/next/app/page.tsx
+++ b/packages/demo-sites/next/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { FormInput, SubmitButton, Card } from "./components";
 
 function CounterDisplay({ count }: { count: number }) {
   return (
@@ -30,6 +31,14 @@ export default function Home() {
   const [networkStatus, setNetworkStatus] = useState("");
   const [consoleStatus, setConsoleStatus] = useState("");
   const [counter, setCounter] = useState(0);
+  const [formName, setFormName] = useState("");
+  const [formEmail, setFormEmail] = useState("");
+  const [formSubmitted, setFormSubmitted] = useState(false);
+
+  function handleFormSubmit() {
+    setFormSubmitted(true);
+    setTimeout(() => setFormSubmitted(false), 2000);
+  }
 
   async function triggerNetworkError() {
     setNetworkStatus("Loading...");
@@ -125,6 +134,36 @@ export default function Home() {
             </NestedComponent>
           </NestedComponent>
         </section>
+
+        <Card title="Form Components Test">
+          <p>フォームコンポーネントのテスト（コンポーネント名の検出確認用）</p>
+          <div className="form-demo">
+            <FormInput
+              label="Name"
+              value={formName}
+              onChange={setFormName}
+              placeholder="Enter your name"
+            />
+            <FormInput
+              label="Email"
+              value={formEmail}
+              onChange={setFormEmail}
+              placeholder="Enter your email"
+            />
+            <div className="button-group">
+              <SubmitButton label="Submit" onClick={handleFormSubmit} />
+              <SubmitButton
+                label="Cancel"
+                onClick={() => {
+                  setFormName("");
+                  setFormEmail("");
+                }}
+                variant="secondary"
+              />
+            </div>
+            {formSubmitted && <p className="status">Form submitted!</p>}
+          </div>
+        </Card>
       </main>
     </div>
   );

--- a/packages/demo-sites/nuxt/components/DemoCard.vue
+++ b/packages/demo-sites/nuxt/components/DemoCard.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+defineProps<{
+  title: string;
+}>();
+</script>
+
+<template>
+  <section class="demo-card">
+    <h2 class="demo-card-title">{{ title }}</h2>
+    <div class="demo-card-content">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.demo-card {
+  background: white;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.demo-card-title {
+  margin-top: 0;
+  color: #333;
+  font-size: 1.25rem;
+}
+
+.demo-card-content {
+  color: #666;
+  line-height: 1.5;
+}
+</style>

--- a/packages/demo-sites/nuxt/components/FormInput.vue
+++ b/packages/demo-sites/nuxt/components/FormInput.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+defineProps<{
+  label: string;
+  modelValue: string;
+  placeholder?: string;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+</script>
+
+<template>
+  <div class="form-input">
+    <label class="form-label">{{ label }}</label>
+    <input
+      type="text"
+      class="form-field"
+      :value="modelValue"
+      :placeholder="placeholder"
+      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+    />
+  </div>
+</template>
+
+<style scoped>
+.form-input {
+  margin-bottom: 1rem;
+}
+
+.form-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #333;
+  margin-bottom: 0.25rem;
+}
+
+.form-field {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.form-field:focus {
+  outline: none;
+  border-color: #0066cc;
+  box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.2);
+}
+</style>

--- a/packages/demo-sites/nuxt/components/SubmitButton.vue
+++ b/packages/demo-sites/nuxt/components/SubmitButton.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+defineProps<{
+  label: string;
+  variant?: "primary" | "secondary" | "danger";
+}>();
+
+const emit = defineEmits<{
+  click: [];
+}>();
+</script>
+
+<template>
+  <button
+    type="button"
+    :class="['submit-button', `submit-button--${variant || 'primary'}`]"
+    @click="emit('click')"
+  >
+    {{ label }}
+  </button>
+</template>
+
+<style scoped>
+.submit-button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.submit-button--primary {
+  background: #0066cc;
+  color: white;
+}
+
+.submit-button--primary:hover {
+  background: #0052a3;
+}
+
+.submit-button--secondary {
+  background: #e0e0e0;
+  color: #333;
+}
+
+.submit-button--secondary:hover {
+  background: #d0d0d0;
+}
+
+.submit-button--danger {
+  background: #cc3300;
+  color: white;
+}
+
+.submit-button--danger:hover {
+  background: #a32900;
+}
+</style>

--- a/packages/demo-sites/nuxt/pages/index.vue
+++ b/packages/demo-sites/nuxt/pages/index.vue
@@ -4,6 +4,21 @@ import { ref } from "vue";
 const networkStatus = ref("");
 const consoleStatus = ref("");
 const counter = ref(0);
+const formName = ref("");
+const formEmail = ref("");
+const formSubmitted = ref(false);
+
+function handleFormSubmit() {
+  formSubmitted.value = true;
+  setTimeout(() => {
+    formSubmitted.value = false;
+  }, 2000);
+}
+
+function clearForm() {
+  formName.value = "";
+  formEmail.value = "";
+}
 
 async function triggerNetworkError() {
   networkStatus.value = "Loading...";
@@ -96,6 +111,27 @@ function incrementCounter() {
           </NestedComponent>
         </NestedComponent>
       </section>
+
+      <DemoCard title="Form Components Test">
+        <p>フォームコンポーネントのテスト（コンポーネント名の検出確認用）</p>
+        <div class="form-demo">
+          <FormInput
+            v-model="formName"
+            label="Name"
+            placeholder="Enter your name"
+          />
+          <FormInput
+            v-model="formEmail"
+            label="Email"
+            placeholder="Enter your email"
+          />
+          <div class="button-group">
+            <SubmitButton label="Submit" @click="handleFormSubmit" />
+            <SubmitButton label="Cancel" variant="secondary" @click="clearForm" />
+          </div>
+          <p v-if="formSubmitted" class="status">Form submitted!</p>
+        </div>
+      </DemoCard>
     </main>
   </div>
 </template>

--- a/packages/extension/src/content/index.ts
+++ b/packages/extension/src/content/index.ts
@@ -37,9 +37,9 @@ function installPageContextCapture() {
       safeSendMessage({ type: "CONSOLE_EVENT", payload });
     } else if (type === "network") {
       safeSendMessage({ type: "NETWORK_EVENT", payload });
-    } else if (type === "vue_component") {
-      // Cache Vue component info on elements
-      handleVueComponentResult(payload);
+    } else if (type === "framework_component") {
+      // Cache framework component info on elements
+      handleFrameworkComponentResult(payload);
     }
   }) as EventListener);
 }
@@ -47,9 +47,9 @@ function installPageContextCapture() {
 // Pending Vue component detection requests
 const pendingVueRequests = new Map();
 
-function requestVueComponentInfo(element, selector) {
-  // Request Vue component info from page context
-  window.dispatchEvent(new CustomEvent("__tossue_get_vue_component__", {
+function requestFrameworkComponentInfo(element, selector) {
+  // Request framework component info from page context
+  window.dispatchEvent(new CustomEvent("__tossue_get_framework_component__", {
     detail: { selector }
   }));
 
@@ -66,14 +66,14 @@ function requestVueComponentInfo(element, selector) {
   });
 }
 
-function handleVueComponentResult(payload) {
+function handleFrameworkComponentResult(payload) {
   const { selector, component } = payload;
   const pending = pendingVueRequests.get(selector);
   if (pending) {
     pendingVueRequests.delete(selector);
     // Cache the result on the element
     if (pending.element) {
-      pending.element.__tossue_vue_info__ = component;
+      pending.element.__tossue_framework_info__ = component;
     }
     pending.resolve(component);
   }
@@ -418,10 +418,10 @@ function paintOutline(element) {
   overlayState.outline.style.width = `${rect.width}px`;
   overlayState.outline.style.height = `${rect.height}px`;
 
-  // Request Vue component info for this element (will be cached)
+  // Request framework component info for this element (will be cached)
   const selector = buildSelector(element);
-  if (selector && !element.__tossue_vue_info__) {
-    requestVueComponentInfo(element, selector).then((info) => {
+  if (selector && !element.__tossue_framework_info__) {
+    requestFrameworkComponentInfo(element, selector).then((info) => {
       // Update hover label if still hovering the same element
       if (overlayState.hoveredElement === element && info) {
         paintHoverLabel(element, rect);
@@ -744,77 +744,15 @@ function detectBrowserLabel() {
 }
 
 function detectFrameworkInfo(element) {
-  const reactInfo = detectReactInfo(element);
-  if (reactInfo) {
-    return reactInfo;
-  }
-
-  // Check cached Vue info first (set by injected script)
-  const cachedVue = element.__tossue_vue_info__;
-  if (cachedVue) {
-    return cachedVue;
+  // Check cached framework info (set by injected script)
+  const cached = element.__tossue_framework_info__;
+  if (cached) {
+    return cached;
   }
 
   return null;
 }
 
-function detectReactInfo(element) {
-  let current = element;
-
-  while (current) {
-    const fiber = findReactFiber(current);
-    if (fiber) {
-      const trail = buildReactComponentTrail(fiber).filter(Boolean);
-      return {
-        framework: "React",
-        selectedComponent: trail[0] || "",
-        componentTrail: trail.slice(0, 6)
-      };
-    }
-
-    current = current.parentElement;
-  }
-
-  return null;
-}
-
-function findReactFiber(element) {
-  for (const key of Object.keys(element)) {
-    if (key.startsWith("__reactFiber$") || key.startsWith("__reactInternalInstance$")) {
-      return element[key];
-    }
-  }
-
-  return null;
-}
-
-function buildReactComponentTrail(fiber) {
-  const trail = [];
-  let current = fiber;
-
-  while (current && trail.length < 6) {
-    const name = getReactComponentName(current);
-    if (name && !trail.includes(name)) {
-      trail.push(name);
-    }
-    current = current.return;
-  }
-
-  return trail;
-}
-
-function getReactComponentName(fiber) {
-  const type = fiber.elementType || fiber.type;
-  if (!type) {
-    return "";
-  }
-
-  if (typeof type === "string") {
-    return type;
-  }
-
-  return type.displayName || type.name || "";
-}
 
 
 function detectDomTreeInfo(element) {

--- a/packages/extension/src/content/index.ts
+++ b/packages/extension/src/content/index.ts
@@ -6,7 +6,8 @@ const overlayState = {
   captureBox: null,
   previewOutline: null,
   toast: null,
-  dragStart: null
+  dragStart: null,
+  hoverLabel: null
 };
 
 const recentActions = [];
@@ -36,8 +37,46 @@ function installPageContextCapture() {
       safeSendMessage({ type: "CONSOLE_EVENT", payload });
     } else if (type === "network") {
       safeSendMessage({ type: "NETWORK_EVENT", payload });
+    } else if (type === "vue_component") {
+      // Cache Vue component info on elements
+      handleVueComponentResult(payload);
     }
   }) as EventListener);
+}
+
+// Pending Vue component detection requests
+const pendingVueRequests = new Map();
+
+function requestVueComponentInfo(element, selector) {
+  // Request Vue component info from page context
+  window.dispatchEvent(new CustomEvent("__tossue_get_vue_component__", {
+    detail: { selector }
+  }));
+
+  // Store a promise that will be resolved when we get the result
+  return new Promise((resolve) => {
+    pendingVueRequests.set(selector, { element, resolve });
+    // Timeout after 100ms
+    setTimeout(() => {
+      if (pendingVueRequests.has(selector)) {
+        pendingVueRequests.delete(selector);
+        resolve(null);
+      }
+    }, 100);
+  });
+}
+
+function handleVueComponentResult(payload) {
+  const { selector, component } = payload;
+  const pending = pendingVueRequests.get(selector);
+  if (pending) {
+    pendingVueRequests.delete(selector);
+    // Cache the result on the element
+    if (pending.element) {
+      pending.element.__tossue_vue_info__ = component;
+    }
+    pending.resolve(component);
+  }
 }
 
 function installMessageListener() {
@@ -203,6 +242,8 @@ function stopAreaPicker() {
   overlayState.outline = null;
   overlayState.captureBox?.remove();
   overlayState.captureBox = null;
+  overlayState.hoverLabel?.remove();
+  overlayState.hoverLabel = null;
 }
 
 function handlePointerMove(event) {
@@ -376,6 +417,91 @@ function paintOutline(element) {
   overlayState.outline.style.top = `${rect.top}px`;
   overlayState.outline.style.width = `${rect.width}px`;
   overlayState.outline.style.height = `${rect.height}px`;
+
+  // Request Vue component info for this element (will be cached)
+  const selector = buildSelector(element);
+  if (selector && !element.__tossue_vue_info__) {
+    requestVueComponentInfo(element, selector).then((info) => {
+      // Update hover label if still hovering the same element
+      if (overlayState.hoveredElement === element && info) {
+        paintHoverLabel(element, rect);
+      }
+    });
+  }
+
+  // Show component label on hover (like Nuxt DevTools)
+  paintHoverLabel(element, rect);
+}
+
+function paintHoverLabel(element, rect) {
+  // Create hover label if not exists
+  if (!overlayState.hoverLabel) {
+    overlayState.hoverLabel = createHoverLabel();
+    document.documentElement.appendChild(overlayState.hoverLabel);
+  }
+
+  // Get component info
+  const framework = detectFrameworkInfo(element);
+  const tagName = element.tagName.toLowerCase();
+
+  let labelText = "";
+  let hasComponent = false;
+
+  if (framework?.selectedComponent && framework.framework !== "DOM") {
+    labelText = `<${tagName}> ${framework.selectedComponent}`;
+    if (framework.filePath) {
+      labelText += `:${framework.filePath.split(":").slice(1).join(":")}`;
+    }
+    hasComponent = true;
+  } else {
+    // DOM fallback
+    const id = element.id ? `#${element.id}` : "";
+    const classes = element.classList.length > 0 ? `.${Array.from(element.classList).slice(0, 2).join(".")}` : "";
+    labelText = `<${tagName}>${id}${classes}`;
+  }
+
+  // Position label at bottom-left of element
+  const label = overlayState.hoverLabel;
+  label.textContent = labelText;
+  label.style.display = "block";
+
+  // Style based on whether it's a component
+  if (hasComponent) {
+    label.style.background = "rgba(16, 185, 129, 0.95)";
+  } else {
+    label.style.background = "rgba(59, 130, 246, 0.95)";
+  }
+
+  // Position: prefer bottom-left, but adjust if off-screen
+  let left = rect.left;
+  let top = rect.bottom + 4;
+
+  // Adjust if label would be off-screen
+  if (top + 28 > window.innerHeight) {
+    top = rect.top - 28;
+  }
+  if (left < 4) {
+    left = 4;
+  }
+
+  label.style.left = `${left}px`;
+  label.style.top = `${top}px`;
+}
+
+function createHoverLabel() {
+  const label = document.createElement("div");
+  label.style.position = "fixed";
+  label.style.zIndex = "2147483647";
+  label.style.padding = "4px 8px";
+  label.style.borderRadius = "4px";
+  label.style.background = "rgba(16, 185, 129, 0.95)";
+  label.style.color = "#fff";
+  label.style.font = '600 12px "SF Mono", "Monaco", monospace';
+  label.style.whiteSpace = "nowrap";
+  label.style.pointerEvents = "none";
+  label.style.display = "none";
+  label.style.boxShadow = "0 2px 8px rgba(0,0,0,0.2)";
+  return label;
 }
 
 function flashSelectionFeedback(element) {
@@ -623,9 +749,10 @@ function detectFrameworkInfo(element) {
     return reactInfo;
   }
 
-  const vueInfo = detectVueInfo(element);
-  if (vueInfo) {
-    return vueInfo;
+  // Check cached Vue info first (set by injected script)
+  const cachedVue = element.__tossue_vue_info__;
+  if (cachedVue) {
+    return cachedVue;
   }
 
   return null;
@@ -689,25 +816,6 @@ function getReactComponentName(fiber) {
   return type.displayName || type.name || "";
 }
 
-function detectVueInfo(element) {
-  let current = element;
-
-  while (current) {
-    const instance = current.__vueParentComponent || current.__vue_app__?._instance || null;
-    if (instance) {
-      const trail = buildVueComponentTrail(instance).filter(Boolean);
-      return {
-        framework: "Vue",
-        selectedComponent: trail[0] || "",
-        componentTrail: trail.slice(0, 6)
-      };
-    }
-
-    current = current.parentElement;
-  }
-
-  return null;
-}
 
 function detectDomTreeInfo(element) {
   const trail = buildDomComponentTrail(element);
@@ -755,34 +863,6 @@ function describeDomNode(element) {
   }
 
   return tag;
-}
-
-function buildVueComponentTrail(instance) {
-  const trail = [];
-  let current = instance;
-
-  while (current && trail.length < 6) {
-    const name = getVueComponentName(current);
-    if (name && !trail.includes(name)) {
-      trail.push(name);
-    }
-    current = current.parent;
-  }
-
-  return trail;
-}
-
-function getVueComponentName(instance) {
-  const type = instance.type || instance.vnode?.type;
-  if (!type) {
-    return "";
-  }
-
-  if (typeof type === "string") {
-    return type;
-  }
-
-  return type.name || type.__name || instance.proxy?.$options?.name || "";
 }
 
 function buildSelector(element) {

--- a/packages/extension/src/content/injected.ts
+++ b/packages/extension/src/content/injected.ts
@@ -204,7 +204,8 @@
 
     while (current && trail.length < 6) {
       const name = getReactComponentName(current);
-      if (name && !trail.includes(name)) {
+      // Only include user-defined components (PascalCase), skip native DOM elements
+      if (name && !trail.includes(name) && isUserComponent(name)) {
         trail.push(name);
       }
       current = current.return as typeof current;
@@ -218,6 +219,12 @@
     if (!type) return "";
     if (typeof type === "string") return type;
     return type.displayName || type.name || "";
+  }
+
+  function isUserComponent(name: string): boolean {
+    // User-defined React components start with uppercase letter (PascalCase)
+    // Native DOM elements are lowercase (div, input, span, etc.)
+    return /^[A-Z]/.test(name);
   }
 
   function getVueComponentInfo(element: Element): { framework: string; selectedComponent: string; componentTrail: string[]; filePath?: string } | null {
@@ -289,7 +296,8 @@
 
     while (current && trail.length < 6) {
       const name = getVue3ComponentName(current);
-      if (name && !trail.includes(name)) {
+      // Only include user-defined components, skip internal Vue components
+      if (name && !trail.includes(name) && isUserComponent(name)) {
         trail.push(name);
       }
       current = current.parent as typeof current;

--- a/packages/extension/src/content/injected.ts
+++ b/packages/extension/src/content/injected.ts
@@ -135,4 +135,108 @@
       at: new Date().toISOString(),
     });
   });
+
+  // Vue component detection - runs in page context where Vue internals are accessible
+  window.addEventListener("__tossue_get_vue_component__", ((event: CustomEvent) => {
+    const { selector } = event.detail || {};
+    if (!selector) return;
+
+    try {
+      const element = document.querySelector(selector);
+      if (!element) {
+        emit("vue_component", { selector, component: null });
+        return;
+      }
+
+      const info = getVueComponentInfo(element);
+      emit("vue_component", { selector, component: info });
+    } catch (e) {
+      emit("vue_component", { selector, component: null, error: String(e) });
+    }
+  }) as EventListener);
+
+  function getVueComponentInfo(element: Element): { framework: string; selectedComponent: string; componentTrail: string[]; filePath?: string } | null {
+    // Try to find Vue instance on element or ancestors
+    let current: Element | null = element;
+
+    while (current && current !== document.body) {
+      // Check for Vue 3 internal properties
+      const instance = findVue3Instance(current);
+      if (instance) {
+        const trail = buildVue3Trail(instance);
+        if (trail.length > 0) {
+          return {
+            framework: "Vue",
+            selectedComponent: trail[0],
+            componentTrail: trail.slice(0, 6),
+          };
+        }
+      }
+      current = current.parentElement;
+    }
+
+    return null;
+  }
+
+  function findVue3Instance(element: Element): unknown {
+    const el = element as Element & {
+      __vueParentComponent?: unknown;
+      __vue_app__?: { _instance?: unknown };
+      [key: string]: unknown;
+    };
+
+    // Vue 3: __vueParentComponent
+    if (el.__vueParentComponent) {
+      return el.__vueParentComponent;
+    }
+
+    // Vue 3 app root
+    if (el.__vue_app__?._instance) {
+      return el.__vue_app__._instance;
+    }
+
+    // Check for __vnode or other Vue 3 properties
+    try {
+      for (const key of Object.keys(el)) {
+        if (key.startsWith("__vnode")) {
+          const vnode = el[key] as { component?: unknown };
+          if (vnode?.component) {
+            return vnode.component;
+          }
+        }
+        if (key.startsWith("__vue") && key !== "__vue_app__") {
+          const value = el[key] as { type?: unknown; proxy?: unknown };
+          if (value && typeof value === "object" && (value.type || value.proxy)) {
+            return value;
+          }
+        }
+      }
+    } catch {
+      // Ignore
+    }
+
+    return null;
+  }
+
+  function buildVue3Trail(instance: unknown): string[] {
+    const trail: string[] = [];
+    let current = instance as { type?: { name?: string; __name?: string }; parent?: unknown; proxy?: { $options?: { name?: string } } } | null;
+
+    while (current && trail.length < 6) {
+      const name = getVue3ComponentName(current);
+      if (name && !trail.includes(name)) {
+        trail.push(name);
+      }
+      current = current.parent as typeof current;
+    }
+
+    return trail;
+  }
+
+  function getVue3ComponentName(instance: { type?: { name?: string; __name?: string; displayName?: string }; proxy?: { $options?: { name?: string } } }): string {
+    const type = instance.type;
+    if (!type) return "";
+    if (typeof type === "string") return type;
+    return type.name || type.__name || type.displayName || instance.proxy?.$options?.name || "";
+  }
 })();

--- a/packages/extension/src/content/injected.ts
+++ b/packages/extension/src/content/injected.ts
@@ -136,24 +136,89 @@
     });
   });
 
-  // Vue component detection - runs in page context where Vue internals are accessible
-  window.addEventListener("__tossue_get_vue_component__", ((event: CustomEvent) => {
+  // Framework component detection - runs in page context where framework internals are accessible
+  window.addEventListener("__tossue_get_framework_component__", ((event: CustomEvent) => {
     const { selector } = event.detail || {};
     if (!selector) return;
 
     try {
       const element = document.querySelector(selector);
       if (!element) {
-        emit("vue_component", { selector, component: null });
+        emit("framework_component", { selector, component: null });
         return;
       }
 
-      const info = getVueComponentInfo(element);
-      emit("vue_component", { selector, component: info });
+      // Try React first, then Vue
+      const reactInfo = getReactComponentInfo(element);
+      if (reactInfo) {
+        emit("framework_component", { selector, component: reactInfo });
+        return;
+      }
+
+      const vueInfo = getVueComponentInfo(element);
+      emit("framework_component", { selector, component: vueInfo });
     } catch (e) {
-      emit("vue_component", { selector, component: null, error: String(e) });
+      emit("framework_component", { selector, component: null, error: String(e) });
     }
   }) as EventListener);
+
+  // React component detection
+  function getReactComponentInfo(element: Element): { framework: string; selectedComponent: string; componentTrail: string[] } | null {
+    let current: Element | null = element;
+
+    while (current && current !== document.body) {
+      const fiber = findReactFiber(current);
+      if (fiber) {
+        const trail = buildReactTrail(fiber);
+        if (trail.length > 0) {
+          return {
+            framework: "React",
+            selectedComponent: trail[0],
+            componentTrail: trail.slice(0, 6),
+          };
+        }
+      }
+      current = current.parentElement;
+    }
+
+    return null;
+  }
+
+  function findReactFiber(element: Element): unknown {
+    const el = element as Element & { [key: string]: unknown };
+    try {
+      for (const key of Object.keys(el)) {
+        if (key.startsWith("__reactFiber$") || key.startsWith("__reactInternalInstance$")) {
+          return el[key];
+        }
+      }
+    } catch {
+      // Ignore
+    }
+    return null;
+  }
+
+  function buildReactTrail(fiber: unknown): string[] {
+    const trail: string[] = [];
+    let current = fiber as { elementType?: unknown; type?: unknown; return?: unknown } | null;
+
+    while (current && trail.length < 6) {
+      const name = getReactComponentName(current);
+      if (name && !trail.includes(name)) {
+        trail.push(name);
+      }
+      current = current.return as typeof current;
+    }
+
+    return trail;
+  }
+
+  function getReactComponentName(fiber: { elementType?: unknown; type?: unknown }): string {
+    const type = (fiber.elementType || fiber.type) as { displayName?: string; name?: string } | string | null;
+    if (!type) return "";
+    if (typeof type === "string") return type;
+    return type.displayName || type.name || "";
+  }
 
   function getVueComponentInfo(element: Element): { framework: string; selectedComponent: string; componentTrail: string[]; filePath?: string } | null {
     // Try to find Vue instance on element or ancestors

--- a/packages/extension/src/sidepanel/components/ActionTimeline.tsx
+++ b/packages/extension/src/sidepanel/components/ActionTimeline.tsx
@@ -195,6 +195,8 @@ type ActionRowProps = {
 function ActionRow({ action, index, onHover, onLeave, onDelete, onTrimBefore }: ActionRowProps) {
   const label = formatActionTitle(action);
   const detail = formatActionDetail(action);
+  const framework = action.targetInfo?.framework;
+  const hasComponent = framework?.selectedComponent && framework.framework !== "DOM";
 
   return (
     <>
@@ -230,7 +232,12 @@ function ActionRow({ action, index, onHover, onLeave, onDelete, onTrimBefore }: 
         </Button>
         <span class="action-row-index">{formatActionIndex(index + 1)}</span>
         <div class="action-row-copy">
-          <strong class="action-row-title">{label}</strong>
+          <div class="action-row-title-row">
+            <strong class="action-row-title">{label}</strong>
+            {hasComponent && (
+              <span class="action-row-chip">{framework.framework}</span>
+            )}
+          </div>
           {detail && <span class="action-row-detail" title={detail}>{detail}</span>}
         </div>
       </article>

--- a/packages/extension/src/sidepanel/utils/format.ts
+++ b/packages/extension/src/sidepanel/utils/format.ts
@@ -38,17 +38,30 @@ export function formatActionTitle(action: UserAction): string {
     return "Page |";
   }
 
+  const componentName = action.targetInfo?.framework?.selectedComponent;
+  const displayTarget = componentName || action.target || "";
+
   if (action.type === "click" && action.href) {
-    return `click link | ${action.target || ""}`.trim();
+    return `click link | ${displayTarget}`.trim();
   }
 
-  return `${action.type || "action"} | ${action.target || ""}`.trim();
+  return `${action.type || "action"} | ${displayTarget}`.trim();
 }
 
 export function formatActionDetail(action: UserAction): string {
   if (action.kind === "navigation") {
     return simplifyUrl(action.target || "");
   }
+
+  const componentName = action.targetInfo?.framework?.selectedComponent;
+  if (componentName && action.target) {
+    return action.target;
+  }
+
+  if (action.valueSnippet) {
+    return action.valueSnippet;
+  }
+
   return "";
 }
 
@@ -56,7 +69,15 @@ export function formatActionMarkdownLine(action: UserAction, index: number): str
   if (action.kind === "navigation") {
     return `${index + 1}. navigation | ${action.navigationKind || "url change"} | ${action.target || "-"}`;
   }
-  return `${index + 1}. ${action.type} | ${action.target || "-"} | ${action.valueSnippet || "-"}`;
+
+  const framework = action.targetInfo?.framework;
+  const componentName = framework?.selectedComponent;
+  const frameworkLabel = framework?.framework && framework.framework !== "DOM"
+    ? ` [${framework.framework}]`
+    : "";
+  const target = componentName || action.target || "-";
+
+  return `${index + 1}. ${action.type} | ${target}${frameworkLabel} | ${action.valueSnippet || "-"}`;
 }
 
 export function simplifyUrl(value: string): string {

--- a/packages/extension/src/styles/global.css
+++ b/packages/extension/src/styles/global.css
@@ -242,11 +242,17 @@ h3 {
 
 .action-row-copy {
   display: flex;
-  align-items: center;
-  gap: 6px;
+  flex-direction: column;
+  gap: 2px;
   min-width: 0;
   flex: 1 1 auto;
   overflow: hidden;
+}
+
+.action-row-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .action-row-title {
@@ -254,6 +260,18 @@ h3 {
   font-size: 12px;
   line-height: 1.2;
   white-space: nowrap;
+}
+
+.action-row-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.2;
 }
 
 .action-row-detail {


### PR DESCRIPTION
## Summary

- Timeline のアクション表示でコンポーネント名を優先表示
- フレームワークバッジ（React/Vue）をタイムラインに追加
- Markdown 出力にフレームワークラベルを含める
- コンポーネント検出の仕様ドキュメントを追加
- demo-site にテスト用コンポーネントを追加（FormInput, SubmitButton, Card）

## 変更内容

### UI 表示の強化
- `formatActionTitle`: コンポーネント名がある場合は優先表示
- `formatActionDetail`: コンポーネント名がある場合は HTML 要素情報を詳細表示
- `ActionRow`: フレームワークバッジを追加（React/Vue の場合のみ）

### Markdown 出力
- `formatActionMarkdownLine`: フレームワークラベルを追加
  - 例: `1. click | SubmitButton [React] | "送信"`

### 仕様ドキュメント
- `docs/component-detection.md`: コンポーネント検出機能の仕様を追加
- `docs/product-overview.md`: MVP 外から削除、Data Model に FrameworkInfo を追加

## Test plan

- [ ] Next.js デモサイト (`npm run dev:demo:next`) でコンポーネントをクリックし、Timeline にコンポーネント名とバッジが表示されることを確認
- [ ] Nuxt デモサイト (`npm run dev:demo:nuxt`) で同様の確認
- [ ] 通常の HTML サイトでクリックした場合、フレームワークバッジが表示されないことを確認
- [ ] Issue 作成時の Markdown プレビューにコンポーネント情報が含まれることを確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)