### PR TITLE
feat: Helper と Extension 間の永続トークン認証を実装

### DIFF
--- a/packages/extension/src/sidepanel/components/HelperStatus.tsx
+++ b/packages/extension/src/sidepanel/components/HelperStatus.tsx
@@ -1,13 +1,20 @@
-import { useComputed } from "@preact/signals";
-import { currentHelper } from "../store/signals";
-import { refreshHelperState, startHelperLogin } from "../hooks/useHelper";
+import { useComputed, useSignal } from "@preact/signals";
+import { currentHelper, helperAuthState } from "../store/signals";
+import { refreshHelperState, startHelperLogin, saveAuthToken, clearAuthToken } from "../hooks/useHelper";
 
 export function HelperStatus() {
   const helper = useComputed(() => currentHelper.value);
+  const authState = useComputed(() => helperAuthState.value);
+  const tokenInput = useSignal("");
+  const authError = useSignal("");
+  const isSaving = useSignal(false);
+
+  const needsHelperAuth = helper.value.reachable && !authState.value.authenticated;
 
   const getStatusDotClass = () => {
     const h = helper.value;
     if (!h.reachable) return "helper-dot warn";
+    if (!authState.value.authenticated) return "helper-dot warn";
     if (!h.github?.gh_installed) return "helper-dot warn";
     if (!h.github?.authenticated) return "helper-dot warn";
     return "helper-dot ok";
@@ -16,6 +23,7 @@ export function HelperStatus() {
   const getStatusText = () => {
     const h = helper.value;
     if (!h.reachable) return "Offline";
+    if (!authState.value.authenticated) return "Auth Required";
     if (!h.github?.gh_installed) return "gh Missing";
     if (!h.github?.authenticated) return "Login Required";
     return "Ready";
@@ -24,6 +32,7 @@ export function HelperStatus() {
   const getSummaryText = () => {
     const h = helper.value;
     if (!h.reachable) return "Tossue Helper is offline";
+    if (!authState.value.authenticated) return "Extension authentication required";
     if (!h.github?.gh_installed) return "Helper is reachable, but gh is not installed";
     if (!h.github?.authenticated) return "GitHub CLI login is required";
     return "Tossue Helper is ready";
@@ -34,6 +43,9 @@ export function HelperStatus() {
     if (!h.reachable) {
       return "localhost helper に接続できません。`Copy` で手動投稿してください。";
     }
+    if (!authState.value.authenticated) {
+      return "Helper のトレイメニューから「📋 Copy Token」でトークンをコピーし、下に貼り付けてください。";
+    }
     if (!h.github?.gh_installed) {
       return "Tossue Helper は応答していますが、このマシンで `gh` コマンドが見つかりません。";
     }
@@ -41,6 +53,28 @@ export function HelperStatus() {
       return h.github?.error || "Run gh auth login.";
     }
     return `${h.repositories.length} repositories loaded and ready for issue creation.`;
+  };
+
+  const handleSaveToken = async () => {
+    if (!tokenInput.value.trim()) {
+      authError.value = "Please enter a token";
+      return;
+    }
+    isSaving.value = true;
+    authError.value = "";
+    const result = await saveAuthToken(tokenInput.value);
+    isSaving.value = false;
+    if (result.ok) {
+      tokenInput.value = "";
+      await refreshHelperState();
+    } else {
+      authError.value = result.error || "Failed to save token";
+    }
+  };
+
+  const handleClearToken = async () => {
+    await clearAuthToken();
+    await refreshHelperState();
   };
 
   const getAccountText = () => {
@@ -56,7 +90,7 @@ export function HelperStatus() {
     ? `Endpoint: 127.0.0.1:${helper.value.health.port}`
     : "Endpoint: 127.0.0.1:47321";
 
-  const showLoginButton = helper.value.reachable && helper.value.github?.gh_installed && !helper.value.github?.authenticated;
+  const showLoginButton = helper.value.reachable && authState.value.authenticated && helper.value.github?.gh_installed && !helper.value.github?.authenticated;
 
   return (
     <details class="full helper-details">
@@ -79,6 +113,43 @@ export function HelperStatus() {
             <span class="helper-chip" id="helperAccount">{getAccountText()}</span>
           </div>
         </div>
+
+        {/* Token input UI */}
+        {needsHelperAuth && (
+          <div class="helper-auth-section">
+            <div class="auth-code-form">
+              <p class="auth-instruction">Paste token from Helper tray menu:</p>
+              <div class="auth-token-input-row">
+                <input
+                  type="password"
+                  placeholder="Paste token here..."
+                  value={tokenInput.value}
+                  onInput={(e) => { tokenInput.value = (e.target as HTMLInputElement).value; }}
+                  class="auth-token-input"
+                />
+                <button
+                  class="primary"
+                  onClick={handleSaveToken}
+                  disabled={isSaving.value}
+                >
+                  {isSaving.value ? "Verifying..." : "Connect"}
+                </button>
+              </div>
+              {authError.value && <p class="auth-error">{authError.value}</p>}
+            </div>
+          </div>
+        )}
+
+        {/* Authenticated: show disconnect option */}
+        {authState.value.authenticated && (
+          <div class="helper-auth-connected">
+            <span class="auth-connected-text">✅ Extension authenticated</span>
+            <button class="secondary auth-disconnect-btn" onClick={handleClearToken}>
+              Disconnect
+            </button>
+          </div>
+        )}
+
         <div class="button-row">
           {showLoginButton && (
             <button class="secondary" id="loginHelper" onClick={startHelperLogin}>

--- a/packages/extension/src/sidepanel/components/SetupPrompt.tsx
+++ b/packages/extension/src/sidepanel/components/SetupPrompt.tsx
@@ -4,12 +4,15 @@ import {
   issueCreationSettings,
   activeSidepanelTab,
 } from "../store/signals";
-import { refreshHelperState } from "../hooks/useHelper";
+import { refreshHelperState, saveAuthToken } from "../hooks/useHelper";
 import { Card, Button } from "./ui";
 
 export function SetupPrompt() {
   const requirement = setupRequirement.value;
   const [isRetrying, setIsRetrying] = useState(false);
+  const [tokenInput, setTokenInput] = useState("");
+  const [authError, setAuthError] = useState("");
+  const [isConnecting, setIsConnecting] = useState(false);
 
   if (!requirement) {
     return null;
@@ -28,8 +31,26 @@ export function SetupPrompt() {
     }
   };
 
+  const handleConnect = async () => {
+    if (!tokenInput.trim()) {
+      setAuthError("Please enter a token");
+      return;
+    }
+    setIsConnecting(true);
+    setAuthError("");
+    const result = await saveAuthToken(tokenInput);
+    setIsConnecting(false);
+    if (result.ok) {
+      setTokenInput("");
+      await refreshHelperState();
+    } else {
+      setAuthError(result.error || "Failed to connect");
+    }
+  };
+
   const content = getContent(requirement.type);
-  const showRetry = requirement.type.startsWith("helper-");
+  const showRetry = requirement.type === "helper-not-reachable";
+  const showTokenInput = requirement.type === "helper-not-authenticated";
 
   return (
     <Card>
@@ -41,6 +62,31 @@ export function SetupPrompt() {
             <p class="text-xs text-muted m-0">{content.description}</p>
           </div>
         </div>
+
+        {/* Token input for helper-not-authenticated */}
+        {showTokenInput && (
+          <div class="grid gap-2">
+            <div class="auth-token-input-row">
+              <input
+                type="password"
+                placeholder="Paste token here..."
+                value={tokenInput}
+                onInput={(e) => setTokenInput((e.target as HTMLInputElement).value)}
+                class="auth-token-input"
+              />
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleConnect}
+                disabled={isConnecting}
+              >
+                {isConnecting ? "Verifying..." : "Connect"}
+              </Button>
+            </div>
+            {authError && <p class="auth-error">{authError}</p>}
+          </div>
+        )}
+
         <div class="flex gap-2 flex-wrap">
           {showRetry && (
             <Button
@@ -52,13 +98,15 @@ export function SetupPrompt() {
               {isRetrying ? "Checking..." : "Retry Connection"}
             </Button>
           )}
-          <Button
-            variant={showRetry ? "secondary" : "primary"}
-            size="sm"
-            onClick={goToSettings}
-          >
-            {content.action}
-          </Button>
+          {!showTokenInput && (
+            <Button
+              variant={showRetry ? "secondary" : "primary"}
+              size="sm"
+              onClick={goToSettings}
+            >
+              {content.action}
+            </Button>
+          )}
           <Button
             variant="secondary"
             size="sm"
@@ -101,6 +149,14 @@ function getContent(type: string): SetupContent {
         description:
           "The Tossue Helper app is not running. Start it to create issues via gh CLI.",
         action: "Setup Helper",
+      };
+    case "helper-not-authenticated":
+      return {
+        icon: "🔑",
+        title: "Connect to Helper",
+        description:
+          "Copy the token from Helper's tray menu (📋 Copy Token) and paste below.",
+        action: "Go to Settings",
       };
     case "helper-gh-not-installed":
       return {

--- a/packages/extension/src/sidepanel/components/settings/HelperSettings.tsx
+++ b/packages/extension/src/sidepanel/components/settings/HelperSettings.tsx
@@ -1,12 +1,40 @@
-import { currentHelper } from "../../store/signals";
-import { refreshHelperState, startHelperLogin } from "../../hooks/useHelper";
+import { useSignal } from "@preact/signals";
+import { currentHelper, helperAuthState } from "../../store/signals";
+import { refreshHelperState, startHelperLogin, saveAuthToken, clearAuthToken } from "../../hooks/useHelper";
 import { Button } from "../ui";
 
 export function HelperSettings() {
   const helper = currentHelper.value;
+  const authState = helperAuthState.value;
+  const tokenInput = useSignal("");
+  const authError = useSignal("");
+  const isSaving = useSignal(false);
 
+  const needsTokenAuth = helper.reachable && !authState.authenticated;
   const showLoginButton =
-    helper.reachable && helper.github?.gh_installed && !helper.github?.authenticated;
+    helper.reachable && authState.authenticated && helper.github?.gh_installed && !helper.github?.authenticated;
+
+  const handleConnect = async () => {
+    if (!tokenInput.value.trim()) {
+      authError.value = "Please enter a token";
+      return;
+    }
+    isSaving.value = true;
+    authError.value = "";
+    const result = await saveAuthToken(tokenInput.value);
+    isSaving.value = false;
+    if (result.ok) {
+      tokenInput.value = "";
+      await refreshHelperState();
+    } else {
+      authError.value = result.error || "Failed to connect";
+    }
+  };
+
+  const handleDisconnect = async () => {
+    await clearAuthToken();
+    await refreshHelperState();
+  };
 
   return (
     <div class="mode-details-content">
@@ -19,23 +47,32 @@ export function HelperSettings() {
         {helper.reachable && (
           <>
             <div class="settings-status">
-              <span
-                class={`settings-status-dot ${helper.github?.gh_installed ? "ok" : "warn"}`}
-              />
-              <span>gh CLI: {helper.github?.gh_installed ? "Installed" : "Not installed"}</span>
+              <span class={`settings-status-dot ${authState.authenticated ? "ok" : "warn"}`} />
+              <span>Extension: {authState.authenticated ? "Authenticated" : "Not authenticated"}</span>
             </div>
 
-            <div class="settings-status">
-              <span
-                class={`settings-status-dot ${helper.github?.authenticated ? "ok" : "warn"}`}
-              />
-              <span>
-                Auth:{" "}
-                {helper.github?.authenticated
-                  ? `@${helper.github.login || "authenticated"}`
-                  : "Not authenticated"}
-              </span>
-            </div>
+            {authState.authenticated && (
+              <>
+                <div class="settings-status">
+                  <span
+                    class={`settings-status-dot ${helper.github?.gh_installed ? "ok" : "warn"}`}
+                  />
+                  <span>gh CLI: {helper.github?.gh_installed ? "Installed" : "Not installed"}</span>
+                </div>
+
+                <div class="settings-status">
+                  <span
+                    class={`settings-status-dot ${helper.github?.authenticated ? "ok" : "warn"}`}
+                  />
+                  <span>
+                    Auth:{" "}
+                    {helper.github?.authenticated
+                      ? `@${helper.github.login || "authenticated"}`
+                      : "Not authenticated"}
+                  </span>
+                </div>
+              </>
+            )}
           </>
         )}
       </div>
@@ -51,7 +88,35 @@ export function HelperSettings() {
         </div>
       )}
 
-      {helper.reachable && (
+      {/* Token input UI when Helper is reachable but extension not authenticated */}
+      {needsTokenAuth && (
+        <div class="helper-auth-section mt-3">
+          <p class="text-xs text-muted mb-2">
+            Copy the token from Helper's tray menu (📋 Copy Token) and paste below:
+          </p>
+          <div class="auth-token-input-row">
+            <input
+              type="password"
+              placeholder="Paste token here..."
+              value={tokenInput.value}
+              onInput={(e) => { tokenInput.value = (e.target as HTMLInputElement).value; }}
+              class="auth-token-input"
+            />
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleConnect}
+              disabled={isSaving.value}
+            >
+              {isSaving.value ? "Verifying..." : "Connect"}
+            </Button>
+          </div>
+          {authError.value && <p class="auth-error">{authError.value}</p>}
+        </div>
+      )}
+
+      {/* Authenticated state with disconnect option */}
+      {helper.reachable && authState.authenticated && (
         <div class="flex gap-2 mt-3">
           {showLoginButton && (
             <Button variant="secondary" size="sm" onClick={startHelperLogin}>
@@ -60,6 +125,9 @@ export function HelperSettings() {
           )}
           <Button variant="secondary" size="sm" onClick={refreshHelperState}>
             Refresh
+          </Button>
+          <Button variant="secondary" size="sm" onClick={handleDisconnect}>
+            Disconnect
           </Button>
         </div>
       )}

--- a/packages/extension/src/sidepanel/hooks/useHelper.ts
+++ b/packages/extension/src/sidepanel/hooks/useHelper.ts
@@ -1,18 +1,36 @@
-import { currentHelper, statusMessage, repositoryLabels, isLoadingLabels } from "../store/signals";
+import { currentHelper, statusMessage, repositoryLabels, isLoadingLabels, helperAuthState } from "../store/signals";
 import type { RepositoryLabel } from "../../shared/types";
 
 const HELPER_BASE_URL = "http://127.0.0.1:47321";
+const AUTH_TOKEN_KEY = "tossue_helper_auth_token";
 
 export function useHelper() {
   return {
     refreshHelperState,
     startHelperLogin,
+    loadAuthToken,
+    saveAuthToken,
+    verifyToken,
+    clearAuthToken,
   };
 }
 
 export async function refreshHelperState() {
   try {
-    const health = await helperGet("/health");
+    // /health is public (no auth required)
+    const health = await helperGet("/health", false);
+
+    // Check if we're authenticated with helper
+    if (!helperAuthState.value.authenticated) {
+      currentHelper.value = {
+        reachable: Boolean(health.ok),
+        health,
+        github: null,
+        repositories: [],
+      };
+      return;
+    }
+
     const github = await helperGet("/github/status");
     let repositories: { name_with_owner: string }[] = [];
 
@@ -49,24 +67,106 @@ export async function startHelperLogin() {
   }
 }
 
-async function helperGet(path: string) {
-  const response = await fetch(`${HELPER_BASE_URL}${path}`);
+function getAuthHeaders(): HeadersInit {
+  const token = helperAuthState.value.token;
+  if (token) {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return {};
+}
+
+async function helperGet(path: string, requireAuth = true) {
+  const headers: HeadersInit = requireAuth ? getAuthHeaders() : {};
+  const response = await fetch(`${HELPER_BASE_URL}${path}`, { headers });
   const payload = await response.json();
   if (!response.ok) {
+    if (response.status === 401) {
+      helperAuthState.value = { ...helperAuthState.value, authenticated: false };
+    }
     throw new Error(payload.error || `Helper request failed: ${path}`);
   }
   return payload;
 }
 
-async function helperPost(path: string) {
+async function helperPost(path: string, body?: unknown, requireAuth = true) {
+  const headers: HeadersInit = {
+    ...(requireAuth ? getAuthHeaders() : {}),
+    ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+  };
   const response = await fetch(`${HELPER_BASE_URL}${path}`, {
     method: "POST",
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
   });
   const payload = await response.json();
   if (!response.ok) {
+    if (response.status === 401) {
+      helperAuthState.value = { ...helperAuthState.value, authenticated: false };
+    }
     throw new Error(payload.error || `Helper request failed: ${path}`);
   }
   return payload;
+}
+
+// Load auth token from chrome.storage on startup
+export async function loadAuthToken(): Promise<void> {
+  try {
+    const result = await chrome.storage.local.get(AUTH_TOKEN_KEY);
+    const token = result[AUTH_TOKEN_KEY];
+    if (token) {
+      // Verify the token is still valid
+      const isValid = await verifyToken(token);
+      if (isValid) {
+        helperAuthState.value = {
+          authenticated: true,
+          token,
+        };
+        return;
+      }
+    }
+    helperAuthState.value = { authenticated: false, token: null };
+  } catch {
+    helperAuthState.value = { authenticated: false, token: null };
+  }
+}
+
+// Save token and verify it
+export async function saveAuthToken(token: string): Promise<{ ok: boolean; error?: string }> {
+  const trimmedToken = token.trim();
+  if (!trimmedToken) {
+    return { ok: false, error: "Token cannot be empty" };
+  }
+
+  const isValid = await verifyToken(trimmedToken);
+  if (!isValid) {
+    return { ok: false, error: "Invalid token. Make sure you copied the correct token from Helper." };
+  }
+
+  await chrome.storage.local.set({ [AUTH_TOKEN_KEY]: trimmedToken });
+  helperAuthState.value = {
+    authenticated: true,
+    token: trimmedToken,
+  };
+  return { ok: true };
+}
+
+// Verify token against Helper
+export async function verifyToken(token: string): Promise<boolean> {
+  try {
+    // Try to access a protected endpoint with the token
+    const response = await fetch(`${HELPER_BASE_URL}/github/status`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+// Clear auth token
+export async function clearAuthToken(): Promise<void> {
+  await chrome.storage.local.remove(AUTH_TOKEN_KEY);
+  helperAuthState.value = { authenticated: false, token: null };
 }
 
 export async function createIssueViaHelper(
@@ -75,16 +175,21 @@ export async function createIssueViaHelper(
   body: string,
   labels: string[]
 ): Promise<{ issue_url: string }> {
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+    ...getAuthHeaders(),
+  };
   const response = await fetch(`${HELPER_BASE_URL}/issues`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
+    headers,
     body: JSON.stringify({ repo, title, body, labels }),
   });
 
   const payload = await response.json();
   if (!response.ok) {
+    if (response.status === 401) {
+      helperAuthState.value = { ...helperAuthState.value, authenticated: false };
+    }
     throw new Error(payload.error || "Tossue Helper failed to create the issue.");
   }
   return payload;

--- a/packages/extension/src/sidepanel/hooks/useSettings.ts
+++ b/packages/extension/src/sidepanel/hooks/useSettings.ts
@@ -14,7 +14,7 @@ import {
   STORAGE_KEYS,
   DEFAULT_ISSUE_CREATION_SETTINGS,
 } from "../../shared/types";
-import { refreshHelperState } from "./useHelper";
+import { refreshHelperState, loadAuthToken } from "./useHelper";
 
 /**
  * 設定の読み込み・保存を管理するフック
@@ -63,6 +63,8 @@ export async function setCreateMethod(method: IssueCreateMethod) {
   // モード切り替え時に接続状態を再チェック
   switch (method) {
     case "gh-cli":
+      // トークン検証後に Helper 状態を更新
+      await loadAuthToken();
       await refreshHelperState();
       break;
     case "github-api":

--- a/packages/extension/src/sidepanel/hooks/useTabState.ts
+++ b/packages/extension/src/sidepanel/hooks/useTabState.ts
@@ -13,7 +13,7 @@ import {
   captureImageStatus,
   DEFAULT_LABEL_PRESETS,
 } from "../store/signals";
-import { refreshHelperState } from "./useHelper";
+import { refreshHelperState, loadAuthToken } from "./useHelper";
 import type { TabState, Message } from "../../shared/types";
 
 const LABEL_STORAGE_KEY = "labelPresets";
@@ -67,7 +67,7 @@ export function useTabState() {
 async function bootstrap() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   activeTabId.value = tab?.id ?? null;
-  await Promise.all([loadLabelPresets(), loadIssueOptions()]);
+  await Promise.all([loadLabelPresets(), loadIssueOptions(), loadAuthToken()]);
   await Promise.all([refreshState(), refreshHelperState()]);
 }
 

--- a/packages/extension/src/sidepanel/store/signals.ts
+++ b/packages/extension/src/sidepanel/store/signals.ts
@@ -53,6 +53,15 @@ export const currentHelper = signal<HelperState>({
   repositories: [],
 });
 
+// Helper authentication state
+export const helperAuthState = signal<{
+  authenticated: boolean;
+  token: string | null;
+}>({
+  authenticated: false,
+  token: null,
+});
+
 export const recordingState = signal<RecordingState>({
   stream: null,
   recorder: null,
@@ -242,6 +251,7 @@ export const needsSetup = computed(() => {
 export type SetupRequirement =
   | { type: "github-api-not-connected" }
   | { type: "helper-not-reachable" }
+  | { type: "helper-not-authenticated" }
   | { type: "helper-gh-not-installed" }
   | { type: "helper-gh-not-authenticated" }
   | null;
@@ -264,6 +274,10 @@ export const setupRequirement = computed<SetupRequirement>(() => {
       const helper = currentHelper.value;
       if (!helper.reachable) {
         return { type: "helper-not-reachable" };
+      }
+      // Check if extension is authenticated with helper
+      if (!helperAuthState.value.authenticated) {
+        return { type: "helper-not-authenticated" };
       }
       if (!helper.github?.gh_installed) {
         return { type: "helper-gh-not-installed" };

--- a/packages/extension/src/styles/global.css
+++ b/packages/extension/src/styles/global.css
@@ -810,3 +810,77 @@ textarea {
   color: #dc2626;
 }
 
+/* Helper Auth */
+.helper-auth-section {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+}
+
+.auth-code-form {
+  display: grid;
+  gap: 10px;
+}
+
+.auth-instruction {
+  font-size: 13px;
+  color: var(--text);
+}
+
+.auth-code-input-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.auth-code-input {
+  flex: 1;
+  max-width: 120px;
+  padding: 8px 12px;
+  font-size: 18px;
+  font-family: "SF Mono", "Monaco", monospace;
+  letter-spacing: 0.2em;
+  text-align: center;
+}
+
+.auth-token-input-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.auth-token-input {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 13px;
+}
+
+.auth-error {
+  font-size: 12px;
+  color: #dc2626;
+}
+
+.helper-auth-connected {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(43, 138, 62, 0.1);
+  border: 1px solid rgba(43, 138, 62, 0.3);
+}
+
+.auth-connected-text {
+  font-size: 13px;
+  color: #2b8a3e;
+}
+
+.auth-disconnect-btn {
+  padding: 4px 10px;
+  font-size: 11px;
+}
+

--- a/packages/helper/src-tauri/Cargo.lock
+++ b/packages/helper/src-tauri/Cargo.lock
@@ -57,6 +57,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "x11rb",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +554,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -810,6 +851,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1162,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1360,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,7 +1535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3804960be0bb5e4edb1e1ad67afd321a9ecfd875c3e65c099468fd2717d7cae"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1556,6 +1644,20 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -1783,6 +1885,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1995,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,7 +2018,7 @@ dependencies = [
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 1.0.69",
  "windows-sys 0.59.0",
@@ -2045,6 +2163,7 @@ dependencies = [
  "bitflags 2.9.4",
  "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
 ]
 
@@ -2466,6 +2585,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.9.4",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2694,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -2782,6 +2926,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3390,7 +3547,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -3569,6 +3726,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,7 +3914,10 @@ dependencies = [
 name = "tossue-helper"
 version = "0.1.0"
 dependencies = [
+ "arboard",
  "axum",
+ "dirs 5.0.1",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tauri",
@@ -3866,7 +4040,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.59.0",
@@ -4225,6 +4399,12 @@ dependencies = [
  "windows",
  "windows-core 0.58.0",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -4728,6 +4908,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4822,4 +5019,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+dependencies = [
+ "zune-core",
 ]

--- a/packages/helper/src-tauri/Cargo.toml
+++ b/packages/helper/src-tauri/Cargo.toml
@@ -17,6 +17,9 @@ tauri = { version = "=2.0.0", features = ["tray-icon"] }
 tauri-utils = "=2.0.0"
 tokio = { version = "=1.39.3", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
 tower-http = { version = "=0.5.2", features = ["cors"] }
+rand = "0.8"
+arboard = "3"
+dirs = "5"
 
 [features]
 default = ["custom-protocol"]

--- a/packages/helper/src-tauri/src/main.rs
+++ b/packages/helper/src-tauri/src/main.rs
@@ -4,17 +4,22 @@ use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::Arc;
 
-use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::extract::{Path, Request, State};
+use axum::http::{header, HeaderValue, Method, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::TrayIconBuilder;
 use tauri::{ActivationPolicy, Manager, WindowEvent};
 use tokio::process::Command;
+use tokio::sync::RwLock;
 use tokio::time::{sleep, Duration};
 use tower_http::cors::CorsLayer;
 
@@ -23,12 +28,20 @@ const DEFAULT_PORT: u16 = 47321;
 #[derive(Clone)]
 struct AppState {
   port: u16,
+  auth: Arc<RwLock<AuthState>>,
+  app_handle: Option<tauri::AppHandle>,
+}
+
+#[derive(Default)]
+struct AuthState {
+  token: Option<String>,
 }
 
 struct MenuState<R: tauri::Runtime> {
   tray_menu: Menu<R>,
   status_item: MenuItem<R>,
   endpoint_item: MenuItem<R>,
+  token_item: MenuItem<R>,
   account_item: MenuItem<R>,
   repos_item: MenuItem<R>,
   install_item: MenuItem<R>,
@@ -120,6 +133,13 @@ struct ApiLabel {
   description: Option<String>,
 }
 
+#[derive(Serialize)]
+struct TokenStatusResponse {
+  authenticated: bool,
+  token_preview: Option<String>,
+}
+
+
 #[tokio::main]
 async fn main() {
   let port = env::var("TOSSUE_HELPER_PORT")
@@ -135,7 +155,11 @@ async fn main() {
       }
     })
     .setup(move |app| {
-      let state = AppState { port };
+      let state = AppState {
+        port,
+        auth: Arc::new(RwLock::new(AuthState::default())),
+        app_handle: None,
+      };
       app.manage(state.clone());
       app.set_activation_policy(ActivationPolicy::Accessory);
 
@@ -148,21 +172,29 @@ async fn main() {
         false,
         None::<&str>,
       )?;
+      let token_item = MenuItem::with_id(app, "token-line", "Token: loading...", false, None::<&str>)?;
       let account_item = MenuItem::with_id(app, "account-line", "Account: -", false, None::<&str>)?;
       let repos_item = MenuItem::with_id(app, "repos-line", "Repositories: -", false, None::<&str>)?;
       let install_item = MenuItem::with_id(app, "install-gh", "Install gh from cli.github.com", true, None::<&str>)?;
+      let separator = PredefinedMenuItem::separator(app)?;
+      let copy_token_item = MenuItem::with_id(app, "copy-token", "📋 Copy Token", true, None::<&str>)?;
+      let rotate_token_item = MenuItem::with_id(app, "rotate-token", "🔄 Rotate Token", true, None::<&str>)?;
+      let separator2 = PredefinedMenuItem::separator(app)?;
       let refresh_item = MenuItem::with_id(app, "refresh-status", "Refresh Status", true, None::<&str>)?;
       let login_item = MenuItem::with_id(app, "login-terminal", "Login in Terminal", true, None::<&str>)?;
       let quit_item = MenuItem::with_id(app, "quit-helper", "Quit Tossue Helper", true, None::<&str>)?;
-      let separator = PredefinedMenuItem::separator(app)?;
 
       tray_menu.append_items(&[
         &status_item,
         &endpoint_item,
+        &token_item,
         &account_item,
         &repos_item,
         &install_item,
         &separator,
+        &copy_token_item,
+        &rotate_token_item,
+        &separator2,
         &refresh_item,
         &login_item,
         &quit_item,
@@ -172,6 +204,7 @@ async fn main() {
         tray_menu: tray_menu.clone(),
         status_item: status_item.clone(),
         endpoint_item: endpoint_item.clone(),
+        token_item: token_item.clone(),
         account_item: account_item.clone(),
         repos_item: repos_item.clone(),
         install_item: install_item.clone(),
@@ -185,7 +218,7 @@ async fn main() {
         .icon_as_template(true)
         .menu_on_left_click(true)
         .on_menu_event(|app, event| match event.id.as_ref() {
-          "status-line" | "endpoint-line" => {}
+          "status-line" | "endpoint-line" | "token-line" => {}
           "install-gh" => {
             #[cfg(target_os = "macos")]
             {
@@ -198,6 +231,32 @@ async fn main() {
                   .await;
               });
             }
+          }
+          "copy-token" => {
+            let handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+              let state = handle.state::<AppState>();
+              let auth = state.auth.read().await;
+              if let Some(ref token) = auth.token {
+                if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                  let _ = clipboard.set_text(token.clone());
+                }
+              }
+            });
+          }
+          "rotate-token" => {
+            let handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+              let state = handle.state::<AppState>();
+              let new_token = generate_token();
+              {
+                let mut auth = state.auth.write().await;
+                auth.token = Some(new_token.clone());
+              }
+              let _ = save_token(&new_token).await;
+              let _ = update_token_menu(&handle).await;
+              eprintln!("[AUTH] Token rotated");
+            });
           }
           "refresh-status" => {
             let handle = app.clone();
@@ -225,8 +284,11 @@ async fn main() {
 
       let _ = tray_builder.build(app)?;
 
+      let server_handle = app.handle().clone();
+      let mut server_state = state.clone();
+      server_state.app_handle = Some(server_handle);
       tauri::async_runtime::spawn(async move {
-        if let Err(error) = run_http_server(state).await {
+        if let Err(error) = run_http_server(server_state).await {
           eprintln!("Tossue helper server failed: {error}");
         }
       });
@@ -243,15 +305,43 @@ async fn main() {
 }
 
 async fn run_http_server(state: AppState) -> Result<(), String> {
-  let router = Router::new()
+  // Load or generate token on startup
+  let token = load_or_create_token().await;
+  {
+    let mut auth = state.auth.write().await;
+    auth.token = Some(token);
+  }
+
+  // Update tray menu with token preview
+  if let Some(ref handle) = state.app_handle {
+    let _ = update_token_menu(handle).await;
+  }
+
+  // Public routes (no auth required)
+  let public_routes = Router::new()
     .route("/health", get(health))
+    .route("/auth/status", get(auth_status))
+    .with_state(state.clone());
+
+  // Protected routes (auth required)
+  let protected_routes = Router::new()
     .route("/github/status", get(github_status))
     .route("/github/login", post(github_login))
     .route("/github/repositories", get(github_repositories))
     .route("/github/repos/:owner/:repo/labels", get(repository_labels))
     .route("/issues", post(create_issue))
-    .layer(CorsLayer::very_permissive())
+    .layer(middleware::from_fn_with_state(state.clone(), auth_middleware))
     .with_state(state.clone());
+
+  let cors = CorsLayer::new()
+    .allow_origin("*".parse::<HeaderValue>().unwrap())
+    .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+    .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
+
+  let router = Router::new()
+    .merge(public_routes)
+    .merge(protected_routes)
+    .layer(cors);
 
   let addr = SocketAddr::from(([127, 0, 0, 1], state.port));
   let listener = tokio::net::TcpListener::bind(addr)
@@ -261,6 +351,55 @@ async fn run_http_server(state: AppState) -> Result<(), String> {
   axum::serve(listener, router)
     .await
     .map_err(|error| format!("helper server crashed: {error}"))
+}
+
+async fn auth_middleware(
+  State(state): State<AppState>,
+  request: Request,
+  next: Next,
+) -> Response {
+  let auth_header = request
+    .headers()
+    .get(header::AUTHORIZATION)
+    .and_then(|value| value.to_str().ok());
+
+  let provided_token = auth_header.and_then(|header| header.strip_prefix("Bearer "));
+
+  let auth = state.auth.read().await;
+  let is_valid = match (&auth.token, provided_token) {
+    (Some(expected), Some(provided)) => expected == provided,
+    _ => false,
+  };
+  drop(auth);
+
+  if is_valid {
+    next.run(request).await
+  } else {
+    (
+      StatusCode::UNAUTHORIZED,
+      Json(ErrorResponse {
+        error: "Unauthorized. Copy the token from Tossue Helper tray menu and paste it in the extension settings.".into(),
+      }),
+    )
+      .into_response()
+  }
+}
+
+async fn auth_status(State(state): State<AppState>) -> Json<TokenStatusResponse> {
+  let auth = state.auth.read().await;
+  let has_token = auth.token.is_some();
+  let token_preview = auth.token.as_ref().map(|t| {
+    if t.len() > 8 {
+      format!("{}...{}", &t[..4], &t[t.len()-4..])
+    } else {
+      t.clone()
+    }
+  });
+
+  Json(TokenStatusResponse {
+    authenticated: has_token,
+    token_preview,
+  })
 }
 
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
@@ -689,4 +828,81 @@ fn ensure_install_item_hidden<R: tauri::Runtime>(menu_state: &MenuState<R>) -> t
   };
 
   menu_state.tray_menu.remove_at(position).map(|_| ())
+}
+
+// Token management functions
+
+fn get_token_file_path() -> PathBuf {
+  let config_dir = dirs::config_dir()
+    .or_else(dirs::home_dir)
+    .unwrap_or_else(|| PathBuf::from("."));
+  config_dir.join("tossue").join("token")
+}
+
+fn generate_token() -> String {
+  rand::thread_rng()
+    .sample_iter(rand::distributions::Alphanumeric)
+    .take(48)
+    .map(char::from)
+    .collect()
+}
+
+async fn load_or_create_token() -> String {
+  let path = get_token_file_path();
+
+  // Try to load existing token
+  if let Ok(token) = tokio::fs::read_to_string(&path).await {
+    let token = token.trim().to_string();
+    if !token.is_empty() {
+      eprintln!("[AUTH] Loaded existing token from {:?}", path);
+      return token;
+    }
+  }
+
+  // Generate new token
+  let token = generate_token();
+  let _ = save_token(&token).await;
+  eprintln!("[AUTH] Generated new token and saved to {:?}", path);
+  token
+}
+
+async fn save_token(token: &str) -> Result<(), String> {
+  let path = get_token_file_path();
+
+  // Ensure parent directory exists
+  if let Some(parent) = path.parent() {
+    tokio::fs::create_dir_all(parent)
+      .await
+      .map_err(|e| format!("failed to create config directory: {e}"))?;
+  }
+
+  tokio::fs::write(&path, token)
+    .await
+    .map_err(|e| format!("failed to write token file: {e}"))?;
+
+  // Set file permissions to owner-only (Unix)
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::PermissionsExt;
+    let permissions = std::fs::Permissions::from_mode(0o600);
+    let _ = std::fs::set_permissions(&path, permissions);
+  }
+
+  Ok(())
+}
+
+async fn update_token_menu<R: tauri::Runtime>(handle: &tauri::AppHandle<R>) -> tauri::Result<()> {
+  let state = handle.state::<AppState>();
+  let auth = state.auth.read().await;
+
+  let token_text = auth.token.as_ref().map(|t| {
+    if t.len() > 8 {
+      format!("🔑 Token: {}...{}", &t[..4], &t[t.len()-4..])
+    } else {
+      format!("🔑 Token: {}", t)
+    }
+  }).unwrap_or_else(|| "🔑 Token: none".to_string());
+
+  let menu_state = handle.state::<MenuState<R>>();
+  menu_state.token_item.set_text(&token_text)
 }


### PR DESCRIPTION
## Summary
- Helper（localhost API）と Chrome Extension 間の通信をセキュアにするため、永続トークン認証を導入
- 初回起動時に 48 文字のランダムトークンを生成し、`~/.config/tossue/token` に保存
- トレイメニューから「📋 Copy Token」でコピーし、Extension に貼り付けて接続
- `/health` と `/auth/status` 以外のすべてのエンドポイントで認証を必須化

## Test plan
- [ ] Helper を起動し、トレイメニューに「📋 Copy Token」と「🔄 Rotate Token」が表示されることを確認
- [ ] Extension で gh-cli モードを選択し、トークン入力 UI が表示されることを確認
- [ ] Helper のトレイメニューから「📋 Copy Token」でトークンをコピー
- [ ] Extension にトークンを貼り付け、「Connect」をクリックして認証成功することを確認
- [ ] 認証後、gh CLI のステータスと Issue 作成が正常に動作することを確認
- [ ] 「🔄 Rotate Token」でトークンを再生成し、Extension の認証が無効になることを確認
- [ ] 「Disconnect」ボタンで Extension の認証をクリアできることを確認

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)