### PR TITLE
feat(ui): 監視対象タブの表示とリフレッシュ機能 (#40)

### DIFF
--- a/docs/watched-tab-indicator.md
+++ b/docs/watched-tab-indicator.md
@@ -1,0 +1,132 @@
+# 監視対象タブ表示機能
+
+## 概要
+
+サイドパネルで現在監視しているタブを明示的に表示し、必要に応じて切り替えられるようにする。
+
+## 背景・動機
+
+- 現状、サイドパネルを開いた時点のタブが固定されるが、どのタブが対象か表示されていない
+- タブを切り替えると、対象も切り替わったと誤解しやすい
+- 意図せず別タブに対して操作してしまう可能性がある
+
+## 機能仕様
+
+### 1. 監視対象タブ情報の表示
+
+サイドパネルのヘッダー下部に、現在の監視対象タブ情報をコンパクトに表示する。
+
+#### 表示内容
+
+| 項目 | 表示形式 | 例 |
+|------|---------|-----|
+| タイトル | 最大30文字（超過時は truncate） | `Example Page Title...` |
+| URL | ホスト名のみ | `example.com` |
+
+#### レイアウト
+
+```
+┌─────────────────────────────────────────┐
+│  AI-ready issue composer                │
+│  Tossue                      [Refresh]  │
+├─────────────────────────────────────────┤
+│  📍 Example Page Title...               │
+│     example.com            [Switch Tab] │
+└─────────────────────────────────────────┘
+```
+
+### 2. タブ切り替え機能
+
+「Switch Tab」ボタンにより、監視対象を現在アクティブなタブに切り替える。
+
+#### 動作フロー
+
+1. ユーザーが「Switch Tab」ボタンをクリック
+2. 現在のブラウザでアクティブなタブを取得
+3. 監視対象タブを新しいタブに更新
+4. 収集済み状態（actions, console, network, selectedArea 等）をリセット
+5. UI を更新して新しいタブ情報を表示
+
+### 3. 視覚的警告
+
+監視対象タブと現在のアクティブタブが異なる場合、視覚的に区別できるようにする。
+
+#### 警告表示の条件
+
+- 監視対象タブ ID ≠ 現在のアクティブタブ ID
+
+#### 警告スタイル
+
+- 軽い警告色の背景（`bg-yellow-50` または同等）
+- 注意アイコン（⚠）の表示
+- ツールチップ: 「監視対象は別のタブです」
+
+## データ構造
+
+### 監視対象タブ情報
+
+```typescript
+type WatchedTabInfo = {
+  id: number;
+  title: string;
+  url: string;
+};
+```
+
+### シグナル追加
+
+```typescript
+// 監視対象タブの情報
+export const watchedTabInfo = signal<WatchedTabInfo | null>(null);
+
+// 現在のアクティブタブと監視対象タブが異なるかどうか
+export const isWatchingDifferentTab = computed(() => {
+  // chrome.tabs API で現在のアクティブタブを監視
+  // watchedTabInfo.value?.id !== currentActiveTabId
+});
+```
+
+## UI コンポーネント
+
+### WatchedTabIndicator
+
+監視対象タブの情報と切り替えボタンを表示するコンポーネント。
+
+#### ファイル配置
+
+```
+packages/extension/src/sidepanel/components/
+└── WatchedTabIndicator.tsx
+```
+
+#### Props
+
+```typescript
+interface WatchedTabIndicatorProps {
+  // props なし（シグナルから状態を取得）
+}
+```
+
+#### UnoCSS クラス
+
+| 要素 | クラス |
+|------|--------|
+| コンテナ | `flex items-center justify-between gap-2 px-3 py-2 bg-surface rounded-lg border border-border` |
+| 警告時コンテナ | `bg-yellow-50 border-yellow-200` |
+| タブ情報 | `flex-1 min-w-0` |
+| タイトル | `text-sm font-medium text-text truncate` |
+| URL | `text-xs text-muted truncate` |
+| 切り替えボタン | `Button variant="secondary" size="sm"` |
+
+## 実装ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `signals.ts` | `watchedTabInfo` シグナル追加 |
+| `useTabState.ts` | タブ情報の取得・更新ロジック追加 |
+| `WatchedTabIndicator.tsx` | 新規コンポーネント作成 |
+| `App.tsx` | `WatchedTabIndicator` の配置 |
+
+## 関連 Issue
+
+- GitHub Issue #40

--- a/packages/extension/src/content/index.ts
+++ b/packages/extension/src/content/index.ts
@@ -81,6 +81,11 @@ function handleFrameworkComponentResult(payload) {
 
 function installMessageListener() {
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message.type === "PING") {
+      sendResponse({ ok: true, pong: true });
+      return;
+    }
+
     if (message.type === "START_AREA_PICKER") {
       startAreaPicker();
       sendResponse({ ok: true });

--- a/packages/extension/src/shared/types/state.ts
+++ b/packages/extension/src/shared/types/state.ts
@@ -138,3 +138,9 @@ export type RecordingState = {
 export type IssueOptions = {
   includeActions: boolean;
 };
+
+export type WatchedTabInfo = {
+  id: number;
+  title: string;
+  url: string;
+};

--- a/packages/extension/src/sidepanel/App.tsx
+++ b/packages/extension/src/sidepanel/App.tsx
@@ -7,6 +7,7 @@ import { Button } from "./components/ui";
 import { TabBar } from "./components/tabs/TabBar";
 import { MainTab } from "./components/MainTab";
 import { SettingsTab } from "./components/SettingsTab";
+import { WatchedTabIndicator } from "./components/WatchedTabIndicator";
 import { activeSidepanelTab } from "./store/signals";
 
 export function App() {
@@ -27,6 +28,8 @@ export function App() {
           Refresh
         </Button>
       </header>
+
+      <WatchedTabIndicator />
 
       <TabBar />
 

--- a/packages/extension/src/sidepanel/App.tsx
+++ b/packages/extension/src/sidepanel/App.tsx
@@ -1,9 +1,8 @@
-import { useTabState, refreshState } from "./hooks/useTabState";
+import { useTabState } from "./hooks/useTabState";
 import { useRecording } from "./hooks/useRecording";
 import { useCapture } from "./hooks/useCapture";
 import { useDevtoolsStatus } from "./hooks/useDevtoolsStatus";
 import { useSettings } from "./hooks/useSettings";
-import { Button } from "./components/ui";
 import { TabBar } from "./components/tabs/TabBar";
 import { MainTab } from "./components/MainTab";
 import { SettingsTab } from "./components/SettingsTab";
@@ -24,9 +23,6 @@ export function App() {
           <p class="eyebrow">AI-ready issue composer</p>
           <h1>Tossue</h1>
         </div>
-        <Button id="refreshState" variant="secondary" onClick={refreshState}>
-          Refresh
-        </Button>
       </header>
 
       <WatchedTabIndicator />

--- a/packages/extension/src/sidepanel/components/CaptureTools.tsx
+++ b/packages/extension/src/sidepanel/components/CaptureTools.tsx
@@ -35,6 +35,9 @@ export function CaptureTools() {
       <div class="section-title-row">
         <h2 class="text-base font-bold">Captured Context</h2>
       </div>
+      <p class="text-xs text-muted -mt-1">
+        うまく動かない場合はページをリロードしてください
+      </p>
       <div class="capture-tool-grid">
         <Card variant="nested">
           <div class="capture-tool-head">

--- a/packages/extension/src/sidepanel/components/IssueCreator.tsx
+++ b/packages/extension/src/sidepanel/components/IssueCreator.tsx
@@ -90,12 +90,13 @@ export function IssueCreator() {
     const body = markdown.value;
     const title = issueTitle.value;
 
-    if (!draft.summary) {
+    const skipBuiltin = settings.customApi.enabled && settings.customApi.skipBuiltinCreate;
+
+    // Title validation is only required for modes that create actual issues
+    if (!draft.summary && method !== "copy" && !skipBuiltin) {
       statusMessage.value = "Issue Title を入力してください。";
       return;
     }
-
-    const skipBuiltin = settings.customApi.enabled && settings.customApi.skipBuiltinCreate;
 
     // Built-in mode (unless skipped for Custom API only mode)
     if (!skipBuiltin) {

--- a/packages/extension/src/sidepanel/components/MainTab.tsx
+++ b/packages/extension/src/sidepanel/components/MainTab.tsx
@@ -1,4 +1,5 @@
 import { needsSetup } from "../store/signals";
+import { resetStateAfterCreate } from "../hooks/useTabState";
 import { StatusFeedback } from "./StatusFeedback";
 import { SetupPrompt } from "./SetupPrompt";
 import { ReportForm } from "./ReportForm";
@@ -6,6 +7,7 @@ import { CaptureTools } from "./CaptureTools";
 import { ActionTimeline } from "./ActionTimeline";
 import { MarkdownPreview } from "./MarkdownPreview";
 import { IssueCreator } from "./IssueCreator";
+import { Button } from "./ui";
 
 export function MainTab() {
   const showSetup = needsSetup.value;
@@ -21,7 +23,14 @@ export function MainTab() {
 
   return (
     <>
-      <StatusFeedback />
+      <div class="flex items-center gap-2">
+        <div class="flex-1 min-w-0">
+          <StatusFeedback />
+        </div>
+        <Button variant="ghost" size="sm" onClick={resetStateAfterCreate}>
+          Clear
+        </Button>
+      </div>
       <ReportForm />
       <CaptureTools />
       <ActionTimeline />

--- a/packages/extension/src/sidepanel/components/WatchedTabIndicator.tsx
+++ b/packages/extension/src/sidepanel/components/WatchedTabIndicator.tsx
@@ -12,30 +12,25 @@ function getHostname(url: string): string {
   }
 }
 
-function truncate(str: string, maxLength: number): string {
-  if (str.length <= maxLength) return str;
-  return str.slice(0, maxLength - 1) + "\u2026";
-}
-
 export function WatchedTabIndicator(): JSX.Element | null {
   const info = watchedTabInfo.value;
   if (!info) return null;
 
   const isDifferent = isWatchingDifferentTab.value;
   const hostname = getHostname(info.url);
-  const truncatedTitle = truncate(info.title || "Untitled", 30);
+  const title = info.title || "Untitled";
 
   return (
     <div
       class={cn(
-        "flex items-center justify-between gap-2 mx-3 px-3 py-2 rounded-lg border",
+        "flex items-center gap-2 px-3 py-2 rounded-lg border overflow-hidden",
         isDifferent ? "bg-yellow-50 border-yellow-200" : "bg-surface border-border"
       )}
     >
-      <div class="flex-1 min-w-0">
-        <div class="flex items-center gap-1.5">
+      <div class="flex-1 min-w-0 overflow-hidden">
+        <div class="flex items-center gap-1.5 min-w-0">
           {isDifferent && <span class="text-yellow-600 shrink-0">&#9888;</span>}
-          <span class="text-sm font-medium text-text truncate">{truncatedTitle}</span>
+          <span class="text-sm font-medium text-text truncate">{title}</span>
         </div>
         <span class="text-xs text-muted truncate block">{hostname}</span>
       </div>
@@ -44,6 +39,7 @@ export function WatchedTabIndicator(): JSX.Element | null {
         size="sm"
         onClick={switchToCurrentTab}
         disabled={!isDifferent}
+        class="shrink-0"
       >
         Switch Tab
       </Button>

--- a/packages/extension/src/sidepanel/components/WatchedTabIndicator.tsx
+++ b/packages/extension/src/sidepanel/components/WatchedTabIndicator.tsx
@@ -1,0 +1,52 @@
+import type { JSX } from "preact";
+import { watchedTabInfo, isWatchingDifferentTab } from "../store/signals";
+import { switchToCurrentTab } from "../hooks/useTabState";
+import { Button } from "./ui";
+import { cn } from "../utils/cn";
+
+function getHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function truncate(str: string, maxLength: number): string {
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength - 1) + "\u2026";
+}
+
+export function WatchedTabIndicator(): JSX.Element | null {
+  const info = watchedTabInfo.value;
+  if (!info) return null;
+
+  const isDifferent = isWatchingDifferentTab.value;
+  const hostname = getHostname(info.url);
+  const truncatedTitle = truncate(info.title || "Untitled", 30);
+
+  return (
+    <div
+      class={cn(
+        "flex items-center justify-between gap-2 mx-3 px-3 py-2 rounded-lg border",
+        isDifferent ? "bg-yellow-50 border-yellow-200" : "bg-surface border-border"
+      )}
+    >
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-1.5">
+          {isDifferent && <span class="text-yellow-600 shrink-0">&#9888;</span>}
+          <span class="text-sm font-medium text-text truncate">{truncatedTitle}</span>
+        </div>
+        <span class="text-xs text-muted truncate block">{hostname}</span>
+      </div>
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={switchToCurrentTab}
+        disabled={!isDifferent}
+      >
+        Switch Tab
+      </Button>
+    </div>
+  );
+}

--- a/packages/extension/src/sidepanel/hooks/useTabState.ts
+++ b/packages/extension/src/sidepanel/hooks/useTabState.ts
@@ -12,6 +12,8 @@ import {
   selectAreaStatus,
   captureImageStatus,
   DEFAULT_LABEL_PRESETS,
+  watchedTabInfo,
+  currentActiveTabId,
 } from "../store/signals";
 import { refreshHelperState, loadAuthToken } from "./useHelper";
 import type { TabState, Message } from "../../shared/types";
@@ -54,8 +56,22 @@ export function useTabState() {
       }
     };
 
+    // Listen for tab activation changes to update currentActiveTabId
+    const handleTabActivated = (activeInfo: chrome.tabs.TabActiveInfo) => {
+      chrome.windows.getCurrent().then((currentWindow) => {
+        if (activeInfo.windowId === currentWindow.id) {
+          currentActiveTabId.value = activeInfo.tabId;
+        }
+      });
+    };
+
     chrome.runtime.onMessage.addListener(handleMessage);
-    return () => chrome.runtime.onMessage.removeListener(handleMessage);
+    chrome.tabs.onActivated.addListener(handleTabActivated);
+
+    return () => {
+      chrome.runtime.onMessage.removeListener(handleMessage);
+      chrome.tabs.onActivated.removeListener(handleTabActivated);
+    };
   }, []);
 
   return {
@@ -67,6 +83,17 @@ export function useTabState() {
 async function bootstrap() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   activeTabId.value = tab?.id ?? null;
+
+  // Set watched tab info
+  if (tab?.id) {
+    watchedTabInfo.value = {
+      id: tab.id,
+      title: tab.title || "",
+      url: tab.url || "",
+    };
+    currentActiveTabId.value = tab.id;
+  }
+
   await Promise.all([loadLabelPresets(), loadIssueOptions(), loadAuthToken()]);
   await Promise.all([refreshState(), refreshHelperState()]);
 }
@@ -199,4 +226,26 @@ export async function resetStateAfterCreate() {
   // Reset button states
   selectAreaButtonText.value = "Select Area";
   captureButtonText.value = "Start Capture";
+}
+
+export async function switchToCurrentTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) return;
+
+  // Reset state for the new tab
+  await resetStateAfterCreate();
+
+  // Update tab IDs
+  activeTabId.value = tab.id;
+  currentActiveTabId.value = tab.id;
+
+  // Update watched tab info
+  watchedTabInfo.value = {
+    id: tab.id,
+    title: tab.title || "",
+    url: tab.url || "",
+  };
+
+  // Refresh state for the new tab
+  await refreshState();
 }

--- a/packages/extension/src/sidepanel/hooks/useTabState.ts
+++ b/packages/extension/src/sidepanel/hooks/useTabState.ts
@@ -11,6 +11,7 @@ import {
   isCapturing,
   selectAreaStatus,
   captureImageStatus,
+  recordingStatus,
   DEFAULT_LABEL_PRESETS,
   watchedTabInfo,
   currentActiveTabId,
@@ -232,10 +233,7 @@ export async function switchToCurrentTab() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab?.id) return;
 
-  // Reset state for the new tab
-  await resetStateAfterCreate();
-
-  // Update tab IDs
+  // Update tab IDs first
   activeTabId.value = tab.id;
   currentActiveTabId.value = tab.id;
 
@@ -246,6 +244,39 @@ export async function switchToCurrentTab() {
     url: tab.url || "",
   };
 
-  // Refresh state for the new tab
-  await refreshState();
+  // Reset background state for the new tab to start fresh
+  await chrome.runtime.sendMessage({
+    type: "RESET_STATE",
+    tabId: tab.id,
+  });
+
+  // Clear local state
+  const repoToKeep = currentState.value.draft.repo;
+  currentState.value = {
+    ...currentState.value,
+    draft: {
+      repo: repoToKeep,
+      summary: "",
+      currentBehavior: "",
+      expectedBehavior: "",
+      labels: [],
+    },
+    screenshots: [],
+    recordings: [],
+    consoleEntries: [],
+    networkEntries: [],
+    selectedArea: null,
+    captureRect: null,
+    actions: [],
+  };
+  selectedLabels.value = new Set();
+
+  // Reset button texts and active states
+  selectAreaButtonText.value = "Select Area";
+  captureButtonText.value = "Start Capture";
+  isSelectingArea.value = false;
+  isCapturing.value = false;
+  selectAreaStatus.value = "";
+  captureImageStatus.value = "";
+  recordingStatus.value = "";
 }

--- a/packages/extension/src/sidepanel/store/signals.ts
+++ b/packages/extension/src/sidepanel/store/signals.ts
@@ -12,6 +12,7 @@ import type {
   IssueCreationSettings,
   GitHubOAuthState,
   GitHubOAuthRepository,
+  WatchedTabInfo,
 } from "../../shared/types";
 import { DEFAULT_ISSUE_CREATION_SETTINGS } from "../../shared/types";
 import { buildMarkdown } from "../utils/markdown";
@@ -45,6 +46,18 @@ function createEmptyState(): TabState {
 }
 
 export const activeTabId = signal<number | null>(null);
+
+// Watched tab info (the tab we're collecting data for)
+export const watchedTabInfo = signal<WatchedTabInfo | null>(null);
+
+// Current browser active tab ID (for detecting tab switches)
+export const currentActiveTabId = signal<number | null>(null);
+
+// Whether the watched tab differs from the current active tab
+export const isWatchingDifferentTab = computed(() => {
+  if (!watchedTabInfo.value || !currentActiveTabId.value) return false;
+  return watchedTabInfo.value.id !== currentActiveTabId.value;
+});
 export const currentState = signal<TabState>(createEmptyState());
 export const currentHelper = signal<HelperState>({
   reachable: false,


### PR DESCRIPTION
## Summary

- サイドパネル上部に監視対象タブのタイトル/URLを表示
- 「Switch Tab」ボタンで監視対象を現在のアクティブタブに切り替え
- 監視対象タブと現在のアクティブタブが異なる場合に警告スタイルを表示

## Changes

- `WatchedTabInfo` 型を追加
- `watchedTabInfo`, `currentActiveTabId`, `isWatchingDifferentTab` シグナルを追加
- `useTabState` にタブ情報取得と `switchToCurrentTab` 関数を追加
- `WatchedTabIndicator` コンポーネントを新規作成
- 仕様ドキュメント `docs/watched-tab-indicator.md` を追加

## Test plan

- [ ] サイドパネルを開いたときにタブ情報が表示される
- [ ] 別タブに切り替えると警告スタイルが表示される
- [ ] Switch Tab ボタンクリックで監視対象が切り替わる
- [ ] タブ切り替え時に収集済みデータがリセットされる
- [ ] 同一タブ時は Switch Tab ボタンが disabled になる

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)