### PR TITLE
docs(web): add code-signing warning for Helper App

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -177,6 +177,7 @@
           <h3>Helper App</h3>
           <p>Optional desktop app for advanced features like screen recording.</p>
           <a href="https://github.com/monpy/tossue/releases" class="btn btn-secondary" target="_blank" rel="noopener">Download from GitHub</a>
+          <p class="download-note">Note: The app is not code-signed. You may see security warnings on macOS/Windows.</p>
         </div>
       </div>
     </section>

--- a/packages/web/style.css
+++ b/packages/web/style.css
@@ -460,6 +460,13 @@ p {
   margin-top: 0;
 }
 
+.download-note {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  margin-top: 1rem;
+  margin-bottom: 0;
+}
+
 /* Feedback */
 .feedback {
   text-align: center;


### PR DESCRIPTION
## Summary
- Add note that Helper App is not code-signed
- Users may see security warnings on macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)