### PR TITLE
fix: prevent text duplication during IME composition

### DIFF
--- a/packages/extension/src/sidepanel/components/LabelSelector.tsx
+++ b/packages/extension/src/sidepanel/components/LabelSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "preact/hooks";
+import { useState, useEffect, useRef } from "preact/hooks";
 import { useComputed } from "@preact/signals";
 import {
   labelPresets,
@@ -24,6 +24,7 @@ type LabelDisplayItem = {
 
 export function LabelSelector() {
   const [customInput, setCustomInput] = useState("");
+  const isComposing = useRef(false);
   const repo = useComputed(() => currentState.value.draft.repo);
   const repoLabels = useComputed(() => repositoryLabels.value);
   const loading = useComputed(() => isLoadingLabels.value);
@@ -234,7 +235,16 @@ export function LabelSelector() {
               id="customLabelInput"
               placeholder="Add custom label..."
               value={customInput}
-              onInput={(e) => setCustomInput((e.target as HTMLInputElement).value)}
+              onInput={(e) => {
+                if (!isComposing.current) {
+                  setCustomInput((e.target as HTMLInputElement).value);
+                }
+              }}
+              onCompositionStart={() => { isComposing.current = true; }}
+              onCompositionEnd={(e) => {
+                isComposing.current = false;
+                setCustomInput((e.target as HTMLInputElement).value);
+              }}
               onKeyDown={handleKeyDown}
             />
             <Button

--- a/packages/extension/src/sidepanel/components/ReportForm.tsx
+++ b/packages/extension/src/sidepanel/components/ReportForm.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "preact/hooks";
 import { useComputed } from "@preact/signals";
 import {
   currentState,
@@ -21,7 +22,13 @@ export function ReportForm() {
   const oauthRepos = useComputed(() => oauthRepositories.value);
   const isLoadingRepos = useComputed(() => isLoadingOAuthRepos.value);
 
+  // IME composition state tracking
+  const isComposing = useRef(false);
+
   const handleInput = async (field: string, value: string) => {
+    // Skip state updates during IME composition to prevent text duplication
+    if (isComposing.current) return;
+
     const state = currentState.value;
     currentState.value = {
       ...state,
@@ -32,6 +39,16 @@ export function ReportForm() {
       },
     };
     await persistDraft();
+  };
+
+  const handleCompositionStart = () => {
+    isComposing.current = true;
+  };
+
+  const handleCompositionEnd = (field: string, e: CompositionEvent) => {
+    isComposing.current = false;
+    // Update with the final composed value
+    handleInput(field, (e.target as HTMLTextAreaElement | HTMLInputElement).value);
   };
 
   const handleOAuthRepoInput = (e: Event) => {
@@ -102,6 +119,8 @@ export function ReportForm() {
               rows={3}
               value={draft.value.summary}
               onInput={(e) => handleInput("summary", (e.target as HTMLTextAreaElement).value)}
+              onCompositionStart={handleCompositionStart}
+              onCompositionEnd={(e) => handleCompositionEnd("summary", e)}
             />
           </label>
           <label class="full">
@@ -111,6 +130,8 @@ export function ReportForm() {
               rows={4}
               value={draft.value.currentBehavior}
               onInput={(e) => handleInput("currentBehavior", (e.target as HTMLTextAreaElement).value)}
+              onCompositionStart={handleCompositionStart}
+              onCompositionEnd={(e) => handleCompositionEnd("currentBehavior", e)}
             />
           </label>
           <label class="full">
@@ -120,6 +141,8 @@ export function ReportForm() {
               rows={4}
               value={draft.value.expectedBehavior}
               onInput={(e) => handleInput("expectedBehavior", (e.target as HTMLTextAreaElement).value)}
+              onCompositionStart={handleCompositionStart}
+              onCompositionEnd={(e) => handleCompositionEnd("expectedBehavior", e)}
             />
           </label>
           {showLabelSelector && <LabelSelector />}

--- a/packages/extension/src/sidepanel/components/settings/AttachmentSettings.tsx
+++ b/packages/extension/src/sidepanel/components/settings/AttachmentSettings.tsx
@@ -1,17 +1,18 @@
+import { useRef } from "preact/hooks";
 import { issueCreationSettings } from "../../store/signals";
 import { updateIssueCreationSettings } from "../../hooks/useSettings";
 import { Card } from "../ui";
 
 export function AttachmentSettings() {
   const settings = issueCreationSettings.value;
+  const isComposing = useRef(false);
 
   const handleAlwaysDownloadChange = (e: Event) => {
     const checked = (e.target as HTMLInputElement).checked;
     updateIssueCreationSettings({ alwaysDownloadAttachments: checked });
   };
 
-  const handlePathPrefixChange = (e: Event) => {
-    const value = (e.target as HTMLInputElement).value;
+  const handlePathPrefixChange = (value: string) => {
     updateIssueCreationSettings({ downloadPathPrefix: value });
   };
 
@@ -34,7 +35,16 @@ export function AttachmentSettings() {
             <input
               type="text"
               value={settings.downloadPathPrefix || ""}
-              onInput={handlePathPrefixChange}
+              onInput={(e) => {
+                if (!isComposing.current) {
+                  handlePathPrefixChange((e.target as HTMLInputElement).value);
+                }
+              }}
+              onCompositionStart={() => { isComposing.current = true; }}
+              onCompositionEnd={(e) => {
+                isComposing.current = false;
+                handlePathPrefixChange((e.target as HTMLInputElement).value);
+              }}
               placeholder="e.g. Tossue/ or projects/bugs/"
             />
             <p class="text-xs text-muted mt-1">

--- a/packages/extension/src/sidepanel/components/settings/CustomApiSettings.tsx
+++ b/packages/extension/src/sidepanel/components/settings/CustomApiSettings.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useState, useRef } from "preact/hooks";
 import { issueCreationSettings } from "../../store/signals";
 import { setCustomApiSettings } from "../../hooks/useSettings";
 import { Card, Button } from "../ui";
@@ -21,6 +21,7 @@ export function CustomApiSettings() {
   const customApi = issueCreationSettings.value.customApi;
   const [testStatus, setTestStatus] = useState<"idle" | "testing" | "success" | "error">("idle");
   const [testMessage, setTestMessage] = useState("");
+  const isComposing = useRef(false);
 
   const handleToggle = (e: Event) => {
     const target = e.target as HTMLInputElement;
@@ -30,11 +31,10 @@ export function CustomApiSettings() {
     });
   };
 
-  const handleEndpointChange = (e: Event) => {
-    const target = e.target as HTMLInputElement;
+  const handleEndpointChange = (value: string) => {
     setCustomApiSettings({
       ...customApi,
-      endpoint: target.value,
+      endpoint: value,
     });
     setTestStatus("idle");
     setTestMessage("");
@@ -109,7 +109,16 @@ export function CustomApiSettings() {
                 type="url"
                 placeholder="https://your-api.example.com/issues"
                 value={customApi.endpoint || ""}
-                onInput={handleEndpointChange}
+                onInput={(e) => {
+                  if (!isComposing.current) {
+                    handleEndpointChange((e.target as HTMLInputElement).value);
+                  }
+                }}
+                onCompositionStart={() => { isComposing.current = true; }}
+                onCompositionEnd={(e) => {
+                  isComposing.current = false;
+                  handleEndpointChange((e.target as HTMLInputElement).value);
+                }}
               />
             </label>
 


### PR DESCRIPTION
## Summary
- IME（日本語入力）中にテキストが重複するバグを修正
- `onCompositionStart` / `onCompositionEnd` イベントハンドラを追加し、composition中は状態更新をスキップ
- 対象コンポーネント: ReportForm, LabelSelector, CustomApiSettings, AttachmentSettings

## Test plan
- [ ] 日本語IMEでテキストを入力し、重複が発生しないことを確認
- [ ] 英語入力が正常に動作することを確認
- [ ] ビルドが成功することを確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)