### PR TITLE
fix: resolve type errors and update download link

### DIFF
--- a/packages/extension/src/shared/types/messages.ts
+++ b/packages/extension/src/shared/types/messages.ts
@@ -38,7 +38,8 @@ export type MessageType =
   | "TAB_RECORDING_FRAME"
   | "TAB_RECORDING_STOPPED"
   | "DEVTOOLS_STATUS_UPDATE"
-  | "GET_DEVTOOLS_STATUS";
+  | "GET_DEVTOOLS_STATUS"
+  | "RESET_STATE";
 
 export type Message = {
   type: MessageType;

--- a/packages/extension/src/sidepanel/hooks/useSettings.ts
+++ b/packages/extension/src/sidepanel/hooks/useSettings.ts
@@ -81,6 +81,7 @@ export async function setCreateMethod(method: IssueCreateMethod) {
 export async function setCustomApiSettings(settings: {
   enabled: boolean;
   endpoint?: string;
+  skipBuiltinCreate?: boolean;
 }) {
   issueCreationSettings.value = {
     ...issueCreationSettings.value,

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -176,7 +176,7 @@
         <div class="download-card">
           <h3>Helper App</h3>
           <p>Optional desktop app for advanced features like screen recording.</p>
-          <a href="https://github.com/monpy/tossue/releases" class="btn btn-secondary" target="_blank" rel="noopener">Download from GitHub</a>
+          <a href="https://github.com/monpy/tossue/releases/latest" class="btn btn-secondary" target="_blank" rel="noopener">Download Latest Release</a>
           <p class="download-note">Note: The app is not code-signed. You may see security warnings on macOS/Windows.</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add `RESET_STATE` to `MessageType` union type
- Add `skipBuiltinCreate` to `setCustomApiSettings` function type
- Update Helper download link to `/releases/latest`

## Fixes
- Extension build was failing due to type errors
- Web site now links directly to latest release

🤖 Generated with [Claude Code](https://claude.com/claude-code)