### PR TITLE
fix(ci): use cargo tauri-cli instead of npx tauri

### DIFF
--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -69,14 +69,12 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --version "^2.0.0" --locked
+
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          projectPath: packages/helper
-          tauriScript: npx tauri
-          args: --target ${{ matrix.target }}
+        working-directory: packages/helper
+        run: cargo tauri build --target ${{ matrix.target }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Fix Windows/Linux Helper build failures in GitHub Actions.

## Problem
The npm-based `@tauri-apps/cli` fails on Windows/Linux because platform-specific binaries are not correctly installed with `npm ci` in a monorepo setup.

## Solution
Switch to installing `tauri-cli` via cargo which works consistently across all platforms.

## Changes
- Replace `tauri-apps/tauri-action` with direct `cargo tauri build`
- Install tauri-cli via `cargo install tauri-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)